### PR TITLE
선형화 모듈, plotting 모듈 개선 및 core 수정(#58)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import numpy as np
 import numpy.linalg as nla
-
+import matplotlib.pyplot as plt
 from nrfsim.envs.dynamic_soaring import DynamicSoaringEnv
 from nrfsim.utils.plotting import PltModule
 
@@ -37,3 +37,4 @@ labels = ('traj',)
 a = PltModule(time_series, data, variables, quantities)
 a.plot_time(labels)
 a.plot_traj(labels)
+plt.show()

--- a/main_linearization_test.py
+++ b/main_linearization_test.py
@@ -13,6 +13,32 @@ import numpy as np
 x = np.array([2, 2])
 u = np.array([1, 1])
 e = 3
+t = 1
+
+
+def ft(state, input, external, time):
+    x1 = state[0]
+    x2 = state[1]
+    u1 = input[0]
+    u2 = input[1]
+    f1 = (x1 ** 2) * u1 + (x2 ** 3) * u2 * external
+    f2 = x1 + external * u2 - x2 ** 2*time
+    return np.array([f1, f2])
+
+
+dftdx = jacob_analytic(ft, 0)
+A_ft = dftdx(x, u, e, t)
+print('A_f =', A_ft)
+
+A_ft_n = jacob_numerical(ft, 0, x, u, e, t)
+print('A_f_num =', A_ft_n)
+
+dfdu = jacob_analytic(ft, 1)
+B_ft = dfdu(x, u, e, t)
+print('B_f =', B_ft)
+
+B_ft_n = jacob_numerical(ft, 1, x, u, e, t)
+print('B_f_num =', B_ft_n)
 
 
 def f(state, input, external):

--- a/main_missile.py
+++ b/main_missile.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.linalg as nla
 import time
-
+import matplotlib.pyplot as plt
 from nrfsim.envs.stationary_target_interception import StationaryTargetEnv
 from nrfsim.utils.plotting import PltModule
 
@@ -51,3 +51,4 @@ labels = ('obs', 'traj')
 a = PltModule(time_series, data, variables, quantities)
 a.plot_time(labels)
 a.plot_traj(labels)
+plt.show()

--- a/main_two_wheels_robot.py
+++ b/main_two_wheels_robot.py
@@ -1,10 +1,17 @@
 import numpy as np
 from nrfsim.envs.two_wheels_robot_pathplanning import TwoWheelsRobotPathPlanningEnv
+from nrfsim.utils.plotting import PltModule
+import matplotlib.pyplot as plt
+import time
+
 np.random.seed(1)
 env = TwoWheelsRobotPathPlanningEnv(initial_state=np.array([0, 0, 0, 0, 0]).astype('float'))
 time_step = 0.01
 time_series = np.arange(0, 5, time_step)
 obs = env.reset()
+obs_series = np.array([], dtype=np.float64).reshape(0, len(obs))
+start_time = time.time()         # elpased time
+
 for i in time_series:
     controls = np.array([1, 0.5])
     # Need logging here
@@ -13,3 +20,20 @@ for i in time_series:
     if done:
         break
     obs = next_obs
+    obs_series = np.vstack((obs_series, obs))
+
+elapsed_time = time.time() - start_time
+print('simulation time = ', time_series[-1] - time_series[0], '[s]')
+print('elpased time = ', elapsed_time, '[s]')
+
+# plot figures (1)
+data = {'obs': obs_series, 'traj': obs_series[:, 0:2]}
+variables = {'obs': ('x', 'y', 'Vx', 'Vy', 'theta'), 'traj': ('x', 'y')}
+quantities = {'obs': ('distance', 'distance', 'speed', 'speed', 'angle'),
+              'traj': ('distance', 'distance')}
+labels = ('obs', 'traj')
+a = PltModule(time_series, data, variables, quantities)
+a.plot_time(labels)
+a.plot_traj(labels)
+plt.show()
+

--- a/nrfsim/core.py
+++ b/nrfsim/core.py
@@ -85,7 +85,7 @@ class BaseEnv(gym.Env):
 
         derivs = []
         for s, x, u in zip(*map(dict.values, [self.systems, states, controls])):
-            derivs.append(s.deriv(x, t, u, s.external(states, controls)))
+            derivs.append(s.deriv(x, u, s.external(states, controls), t))
 
         return np.hstack(derivs)
 
@@ -99,7 +99,7 @@ class BaseSystem:
         if callable(deriv):
             self.deriv = deriv
 
-    def deriv(self, state, t, control, external):
+    def deriv(self, state, control, external, t):
         raise NotImplementedError("deriv method is not defined in the system.")
 
     def reset(self):

--- a/nrfsim/models/aircraft.py
+++ b/nrfsim/models/aircraft.py
@@ -28,13 +28,13 @@ class Aircraft3Dof(BaseSystem):
         state = states['aircraft']
         return dict(wind=self.wind.get(state))
 
-    def deriv(self, state, t, control, external):
+    def deriv(self, state, control, external, t):
         CL, phi = control
         CD = self.CD0 + self.CD1*CL**2
         raw_control = CD, CL, phi
-        return self._raw_deriv(state, t, raw_control, external)
+        return self._raw_deriv(state, raw_control, external, t)
 
-    def _raw_deriv(self, state, t, control, external):
+    def _raw_deriv(self, state, control, external, t):
         x, y, z, V, gamma, psi = state
         CD, CL, phi = control
         (_, Wy, _), (_, dWydt, _) = external['wind']

--- a/nrfsim/models/missile.py
+++ b/nrfsim/models/missile.py
@@ -26,7 +26,7 @@ class MissilePlanar(BaseSystem):
         return 0
         # return {"wind" : [(0, 0), (0, 0)]} # no external effects
 
-    def deriv(self, state, t, control, external):
+    def deriv(self, state, control, external, t):
         # state and (control) input
         x, y, V, gamma, = state
         a = control

--- a/nrfsim/models/quadrotor.py
+++ b/nrfsim/models/quadrotor.py
@@ -37,7 +37,7 @@ class Quadrotor(BaseSystem):
         *ss, _ = np.split(ss, index)
         return ss
 
-    def deriv(self, state, t, control, external):
+    def deriv(self, state, control, external, t):
         d, c = self.d, self.c
         f, M1, M2, M3 = np.array(
             [[1, 1, 1, 1],

--- a/nrfsim/models/two_wheels_robot.py
+++ b/nrfsim/models/two_wheels_robot.py
@@ -26,7 +26,7 @@ class TwoWheelsRobot3Dof(BaseSystem):
     def external(self, states, controls):
         return 0
         
-    def deriv(self, state, t, control, external):
+    def deriv(self, state, control, external, t):
         x, y, vx, vy, theta = state
         Cbi = np.array([[np.cos(theta), np.sin(theta), 0],
                         [-np.sin(theta), np.cos(theta), 0],

--- a/nrfsim/utils/linearization.py
+++ b/nrfsim/utils/linearization.py
@@ -1,5 +1,6 @@
 import numdifftools as nd
 import numpy as np
+#from inspect import signature
 
 
 def jacob_analytic(functions, i):
@@ -13,11 +14,12 @@ def jacob_analytic(functions, i):
         ``functions`` function that takes at least one positional arguments and
         at most three arguments including positional, arbitrary, keyword args.
         The order of arguments should be
-        'state', *'control input', *'external input'.
+        'state', *'control input', *'the other inputs', *'time'.
 
         -``x``: state (`float` or `int`). It must be taken
         -``u``: control input (`float` or `int`). arbitraty argumnets
-        -``e``: external input (`float` or `int`). arbitraty argumnets
+        -``e``: external input (`float` or `int`). arbitrary argumnets
+        -``t``: time (`float`). arbitrary arguments
     i : int or float
         ``i`` means what will we get Jacobian function for.
         0: first arguments of ``functions``(usually x)
@@ -51,11 +53,12 @@ def jacob_numerical(functions, i, x, *args):
         ``functions`` function that takes at least one positional arguments and
         at most three arguments including positional, arbitrary, keyword args.
         The order of arguments should be
-        'state', *'control input', *'external input'.
+        'state', *'control input', *'external input', *'time'.
 
         -``x``: state (`float` or `int`). It must be taken
-        -``u``: control input (`float` or `int`). arbitraty argumnets
-        -``e``: external input (`float` or `int`). arbitraty argumnets
+        -``u``: control input (`float` or `int`). arbitrary argumnets
+        -``e``: external input (`float` or `int`). arbitrary argumnets
+        -``t``: time. arbitrary arguments
     i : int or float
         ``i`` means what will we get Jacobian function for.
         0: first arguments of ``functions``(usually ``x``)
@@ -73,7 +76,30 @@ def jacob_numerical(functions, i, x, *args):
         jacobian matrix of ``functions`` for ``x``, ``u`` respectively.
     """
     ptrb = 1e-9
-    if len(args) == 2:
+    if len(args) == 3:
+        u = args[0]
+        e = args[1]
+        t = args[2]
+        dx = functions(x, u, e, t)
+        if i == 0:
+            n = np.size(x)
+            dfdx = np.zeros([n, n])
+            for j in np.arange(n):
+                ptrbvec = np.zeros(n)
+                ptrbvec[j] = ptrb
+                dx_ptrb = functions(x + ptrbvec, u, e, t)
+                dfdx[j] = (dx_ptrb - dx) / ptrb
+            return np.transpose(dfdx)
+        else:
+            m = np.size(u)
+            dfdu = np.zeros([m, m])
+            for j in np.arange(m):
+                ptrbvec = np.zeros(m)
+                ptrbvec[j] = ptrb
+                dx_ptrb = functions(x, u + ptrbvec, e, t)
+                dfdu[j] = (dx_ptrb - dx) / ptrb
+            return np.transpose(dfdu)
+    elif len(args) == 2:
         u = args[0]
         e = args[1]
         dx = functions(x, u, e)

--- a/nrfsim/utils/plotting.py
+++ b/nrfsim/utils/plotting.py
@@ -33,7 +33,6 @@ class PltModule:
                     plt.xlabel('t' + ' [' + self.units['time'] + ' ]')
                     plt.ylabel(self.variables[label][i] + ' ['
                                + self.units[self.quantities[label][i]] + ' ]')
-            plt.show()
 
     def plot_traj(self, labels: tuple) -> None:
         if 'traj' in labels:
@@ -49,7 +48,6 @@ class PltModule:
                            + self.units[self.quantities['traj'][0]] + ' ]')
                 plt.ylabel(self.variables['traj'][1] + ' ['
                            + self.units[self.quantities['traj'][1]] + ' ]')
-                plt.show()
             elif len(self.variables['traj']) == 3:
                 x = self.data['traj'][:, 0]
                 y = self.data['traj'][:, 1]
@@ -63,4 +61,3 @@ class PltModule:
                               + self.units[self.quantities['traj'][1]] + ' ]')
                 ax.set_zlabel(self.variables['traj'][2] + ' ['
                               + self.units[self.quantities['traj'][2]] + ' ]')
-                plt.show()


### PR DESCRIPTION
선형화 모듈
이전에는 `input arguments`로 최대 3개(state, control, external)를 받는 함수만 선형화 가능했는데 이제는 4개(state, control, external, time)를 받는 함수까지 가능.
단, 함수를 만들 때 arguments의 순서를 지켜야한다!!!

Plotting 모듈
이제 한 번에 그래프가 모두 뜨도록 변경.
대신 matplotlib.pyplot 을 import 해야 되고 코드 마지막에 plt.show() 해야 한다.

Core
core 내부의 deriv 메소드의 arguments 순서를 (state, t, control, external)에서 (state, control, external, t)로 마지막으로 뺐다. 이를 맞추기 위해 derivs 메소드에서
`for s, x, u in zip(*map(dict.values, [self.systems, states, controls])): derivs.append(s.deriv(x, t, u, s.external(states, controls)))`
를
`for s, x, u in zip(*map(dict.values, [self.systems, states, controls])): derivs.append(s.deriv(x, u, s.external(states, controls), t))`
로 바꿨다. t의 위치를 마지막으로 옮긴 것

Linearization
Existing module only can linearize the funtion that takes, at most,
3 argunments which is state, control input, external input.
Now it can linearize the function which takes, at most, 4 arguments
which is state, control input, external input, and time.

Plotting
Existing module can't show all figures at once. Former figure has to be
closed to show next figure.
Now it can show all figures at once by typing `import matplotlib.pyplot
as plt` at beginning of code and plt.show() at the end of code.

Core
Order of `deriv` method's arguments is change from (state, t, control,
external) to (state, control, external, t)