### PR TITLE
Hotfix/iss5 (쿼드로터 모델 버그 수정)

### DIFF
--- a/nrfsim/models/quadrotor.py
+++ b/nrfsim/models/quadrotor.py
@@ -27,11 +27,18 @@ class Quadrotor(BaseSystem):
     g = 9.81  # m/s^2
     control_size = 4  # f1, f2, f3, f4
     name = 'quadrotor'
-
+    state_lower_bound = np.array(-np.inf * np.ones(18))
+    state_upper_bound = np.array(np.inf * np.ones(18))
+    control_lower_bound = np.array(-np.inf * np.ones(4))
+    control_upper_bound = np.array(-np.inf * np.ones(4))
 
     def __init__(self, initial_state: list):
         super().__init__(self.name, initial_state, self.control_size)
         self.state_index = np.cumsum([3, 3, 9, 3])
+
+    def external(self, states, controls):
+        state = states['quadrotor']
+        return None
 
     def split(self, ss, index):
         *ss, _ = np.split(ss, index)


### PR DESCRIPTION
쿼드로터 모델이 `core.py` 와 호환되지 않는 버그 수정.
- 수정사항
  1) state 와 input 관련 bound 를 property 로 추가
  2) method `external` 추가
- 테스트
  1) zero input 을 주었을 때 문제가 해소됨을 확인
  2) 사진 (주의: NED 좌표계)
  
![image](https://user-images.githubusercontent.com/43136096/63517990-033b6300-c52b-11e9-92d0-da2357d62e3a.png)
![image](https://user-images.githubusercontent.com/43136096/63518009-10585200-c52b-11e9-9ca6-5253f6090453.png)




Note: 용어를 잘 모르니, 틀린 부분이 있으면 리뷰에 추가해주세요.