### PR TITLE
PID 모듈 확인 (#50)

### DIFF
--- a/fym/agents/PID.py
+++ b/fym/agents/PID.py
@@ -5,46 +5,47 @@ import numpy as np
 
 
 class PID():
-    def __init__(self, method='euler', dt=0.01, windup=True):
+    def __init__(self, gain, windup=True, method='euler', dt=0.01):
         self.e_intg = 0
         self.e_prev = 0  # initial guess for differentiator
         self.windup = windup
         self.dt = dt
+        if len(gain) != 3:
+            print("PID gain must consist of three elements,"
+                  "i.e., p, i, and d.")
+        else:
+            self.p = gain[0]
+            self.i = gain[1]
+            self.d = gain[2]
 
         if method == 'euler':
             self.integrate = intg_euler
             self.differentiate = diff_euler
 
-    def input(self, e: float, gain: np.ndarray) -> float:
-        if len(gain) != 3:
-            print("PID gain must consist of three elements,"
-                  "i.e., p, i, and d.")
-        else:
-            p = gain[0]
-            i = gain[1]
-            d = gain[2]
-
+    def input(self, e: float) -> float:
+        
         dt = self.dt
         e_i = self.e_intg
         e_d = self.differentiate(e, self.e_prev, dt)
-        u = p * e + i * e_i + d * e_d
+        u = self.p * e + self.i * e_i + self.d * e_d
 
         # Update
         if self.windup:
-            self.e_intg = windup(self.integrate(e, self.e_intg, dt))
+            self.e_intg = self.int_windup(self.integrate(e, self.e_intg, dt))
         else:
-            self.e_intg = self.integrate(e, self.t_state, dt)
+            self.e_intg = self.integrate(e, self.e_intg, dt)
         self.e_prev = e
 
         return u
 
-
-def windup(x: float, x_min=-100, x_max=100) -> float:
-    if x > x_max:
-        x = x_max
-    elif x < x_min:
-        x = x_min
-    return x
+    def int_windup(self, x: float) -> float:
+        x_max = self.windup
+        x_min = -self.windup
+        if x > x_max:
+            x = x_max
+        elif x < x_min:
+            x = x_min
+        return x
 
 
 def intg_euler(e, e_intg, dt):
@@ -55,13 +56,14 @@ def diff_euler(e, e_prev, dt):
     return (e - e_prev) / dt
 
 
-"""
-below codes: test
-"""
-y = 1
-y_ref = 2
-e = y - y_ref
-gain = np.array([1, 2, 3])
-ctrllr = PID()
-print(ctrllr.input(e, gain))
-# print(ctrllr.e_intg, ctrllr.e_prev)
+if __name__ == '__main__':
+    e = 100
+    gain = np.array([1, 2, 3])
+    ctrllr = PID(gain)
+    print(ctrllr.input(e))
+    print(ctrllr.e_intg, ctrllr.e_prev)
+    e = -100
+    gain = np.array([1, 3, 3])
+    print(ctrllr.input(e))
+    print(ctrllr.e_intg, ctrllr.e_prev)
+

--- a/fym/envs/quadrotor_hovering.py
+++ b/fym/envs/quadrotor_hovering.py
@@ -1,0 +1,79 @@
+import numpy as np
+import gym
+from gym import spaces
+from scipy.spatial.transform import Rotation as R
+
+from fym.models.quadrotor import Quadrotor
+from fym.core import BaseEnv
+
+
+class QuadrotorHoveringEnv(BaseEnv):
+    def __init__(self, initial_state, dt=0.01):
+        quadrotor = Quadrotor(initial_state=initial_state)
+
+        obs_sp = gym.spaces.Box(
+            low=-np.pi * np.ones(18),
+            high=np.pi * np.ones(18),
+            dtype=np.float32,
+        )
+        act_sp = gym.spaces.Box(
+            low=-10000 * np.ones(4),
+            high=10000* np.ones(4),
+            dtype=np.float32,
+        )
+
+        super().__init__(systems=[quadrotor], dt=dt, obs_sp=obs_sp, act_sp=act_sp)
+
+    def reset(self, noise=0):
+        super().reset()
+        self.states['quadrotor'] += np.random.uniform(-noise, noise)
+        return self.get_ob()
+
+    def step(self, action):
+        # ----------------------------------------------------------------------
+        # These lines will be replaced with
+        #   controls = dict(aircraft=action)
+        # lb, ub = self.action_space.low, self.action_space.high
+        # quadrotor_control = (lb + ub)/2 + (ub - lb)/2*np.asarray(action)
+        quadrotor_control = np.asarray(action)
+        controls = dict(quadrotor=quadrotor_control)
+        # ----------------------------------------------------------------------
+
+        states = self.states.copy()
+        next_obs, reward, done, _ = super().step(controls)
+        info = {'states': states, 'next_states': self.states}
+        return next_obs, reward, done, info
+
+    def get_ob(self):
+        states = self.states['quadrotor']
+        return states
+
+    def terminal(self):
+        state = self.states['quadrotor']
+        system = self.systems['quadrotor']
+        lb, ub = system.state_lower_bound, system.state_upper_bound
+        if not np.all([state > lb, state < ub]):
+            return True
+        else:
+            return False
+
+    def get_reward(self, controls):
+        euler = R.from_dcm(
+            self.states['quadrotor'][6:15].reshape(3,3)).as_euler(
+                                                        'zyx', degrees=True)
+        # import ipdb; ipdb.set_trace()
+        att = euler[0:2]
+        att_goal = [0, 0]      # goal attitude (roll, pitch)
+        error = self.weight_norm(att - att_goal, [1, 1])
+        return -error
+
+    def weight_norm(self, v, W):
+        if np.asarray(W).ndim == 1:
+            W = np.diag(W)
+        elif np.asarray(W).ndim > 2:
+            raise ValueError("W must have the dimension less than or equal to 2")
+        return np.sqrt(np.dot(np.dot(v, W), v))
+
+
+if __name__ == '__main__':
+    env = StationaryTargetEnv()

--- a/fym/models/missile.py
+++ b/fym/models/missile.py
@@ -75,5 +75,4 @@ class MissilePlanar(BaseSystem):
         dVdt = (T - D)/m - self.g*np.sin(gamma)
         dgammadt = (a - self.g*np.cos(gamma))/V
 
-        # import ipdb; ipdb.set_trace()
         return np.hstack([dxdt, dydt, dVdt, dgammadt])

--- a/fym/models/quadrotor.py
+++ b/fym/models/quadrotor.py
@@ -30,7 +30,7 @@ class Quadrotor(BaseSystem):
     state_lower_bound = np.array(-np.inf * np.ones(18))
     state_upper_bound = np.array(np.inf * np.ones(18))
     control_lower_bound = np.array(-np.inf * np.ones(4))
-    control_upper_bound = np.array(-np.inf * np.ones(4))
+    control_upper_bound = np.array(np.inf * np.ones(4))
 
     def __init__(self, initial_state: list):
         super().__init__(self.name, initial_state, self.control_size)

--- a/fym/utils/plotting.py
+++ b/fym/utils/plotting.py
@@ -11,7 +11,8 @@ from mpl_toolkits import mplot3d
 
 
 class PltModule:
-    units = {'time': 's', 'distance': 'm', 'speed': 'm/s', 'angle': 'deg'}
+    units = {'time': 's', 'distance': 'm', 'speed': 'm/s', 'angle': 'deg',
+             'force': 'N'}
 
     def __init__(self, time_series: float, data: dict, variables: dict,
                  quantities: dict) -> None:
@@ -28,12 +29,15 @@ class PltModule:
                 if self.quantities[label][i] == 'angle':
                     plt.plot(self.time_series,
                              np.rad2deg(self.data[label][:, i]))
+                    plt.xlabel('t' + ' [' + self.units['time'] + ' ]')
+                    plt.ylabel(self.variables[label][i] + ' ['
+                               + self.units[self.quantities[label][i]] + ' ]')
+
                 else:
                     plt.plot(self.time_series, self.data[label][:, i])
                     plt.xlabel('t' + ' [' + self.units['time'] + ' ]')
                     plt.ylabel(self.variables[label][i] + ' ['
                                + self.units[self.quantities[label][i]] + ' ]')
-            plt.show()
 
     def plot_traj(self, labels: tuple) -> None:
         if 'traj' in labels:
@@ -49,7 +53,6 @@ class PltModule:
                            + self.units[self.quantities['traj'][0]] + ' ]')
                 plt.ylabel(self.variables['traj'][1] + ' ['
                            + self.units[self.quantities['traj'][1]] + ' ]')
-                plt.show()
             elif len(self.variables['traj']) == 3:
                 x = self.data['traj'][:, 0]
                 y = self.data['traj'][:, 1]
@@ -63,4 +66,3 @@ class PltModule:
                               + self.units[self.quantities['traj'][1]] + ' ]')
                 ax.set_zlabel(self.variables['traj'][2] + ' ['
                               + self.units[self.quantities['traj'][2]] + ' ]')
-                plt.show()

--- a/main_test_PID.py
+++ b/main_test_PID.py
@@ -1,12 +1,10 @@
 import numpy as np
-import numpy.linalg as nla
 from scipy.spatial.transform import Rotation as R
 from matplotlib import pyplot as plt
 
 from fym.envs.quadrotor_hovering import QuadrotorHoveringEnv
 from fym.models.quadrotor import Quadrotor
 from fym.utils.plotting import PltModule
-from fym.agents.PID import PID
 
 np.random.seed(1)
 
@@ -18,42 +16,18 @@ initial_state = np.hstack((x0, v0, R0.ravel(), dOmega))
 
 env = QuadrotorHoveringEnv(
     initial_state=initial_state.astype('float'))
-quad = env.systems['quadrotor']
 
 time_step = 0.01
 time_series = np.arange(0, 50, time_step)
 
 obs = env.reset()
 obs_series = np.array([], dtype=np.float64).reshape(0, len(obs))
-ctrl_series = np.array([], dtype=np.float64).reshape(0, 4)
-y_series = np.array([], dtype=np.float64).reshape(0, 3)
-
-pid_roll = PID(1.0 * np.array([1.0, 0.1, 1.0]), windup=False)
-pid_pitch = PID(1.0 * np.array([1.0, 0.1, 1.0]), windup=False)
-pid_height = PID(5 * np.array([1.0, 0.1, 1.0]), windup=10)
-
-y_goal = np.array([0, 0, 0])  # roll, pitch, height
-allocation_matrix = nla.inv(
-    [[0, 1, 0, -1],
-     [-1, 0, 1, 0],
-     [1, 1, 1, 1],
-     [1, -1, 1, -1]]
-)
 
 for i in time_series:
-    euler_angles = obs[3:6]
-    y = np.concatenate((euler_angles[[2, 1]], -obs[2]), axis=None)
-    e_y = y - y_goal
-    f24_diff = pid_roll.get(e_y[0])
-    f31_diff = pid_pitch.get(e_y[1])
-    f1234_sum = pid_height.get(-e_y[2]) + quad.m * quad.g
-    controls = allocation_matrix.dot([f24_diff, f31_diff, f1234_sum, 0])
-
-    next_obs, reward, done, _ = env.step(controls)
+    action = np.array([0, 0, 0])  # desired height, pitch, roll
+    next_obs, reward, done, _ = env.step(action)
 
     obs_series = np.vstack((obs_series, obs))
-    ctrl_series = np.vstack((ctrl_series, controls))
-    y_series = np.vstack((y_series, y))
 
     if done:
         break
@@ -68,23 +42,20 @@ NED2ENU = np.array([[0, 1, 0],
 
 data = {
     'traj': obs_series[:, 0:3].dot(NED2ENU),
-    'input': ctrl_series,
-    'output': y_series
+    'output': obs_series[:, [2, 4, 5]]
 }
 
 variables = {
     'traj': ('x', 'y', 'z'),
-    'input': ('f1', 'f2', 'f3', 'f4'),
-    'output': ('roll', 'pitch', 'height')
+    'output': ('height', 'pitch', 'roll')
 }
 
 quantities = {
     'traj': ('distance', 'distance', 'distance'),
-    'input': ('force', 'force', 'force', 'force'),
-    'output': ('angle', 'angle', 'distance')
+    'output': ('distance', 'angle', 'angle')
 }
 
-labels = ('traj', 'input', 'output')
+labels = ('traj', 'output')
 
 a = PltModule(time_series, data, variables, quantities)
 a.plot_time(labels)

--- a/main_test_PID.py
+++ b/main_test_PID.py
@@ -1,0 +1,76 @@
+import numpy as np
+import numpy.linalg as nla
+from scipy.spatial.transform import Rotation as R
+from matplotlib import pyplot as plt
+from numpy.linalg import inv
+
+from fym.envs.quadrotor_hovering import QuadrotorHoveringEnv
+from fym.models.quadrotor import Quadrotor
+from fym.utils.plotting import PltModule
+from fym.agents.PID import PID
+
+np.random.seed(1)
+
+x0 = [0, 0, -5]
+v0 = [0, 0, 0]
+R0 = R.from_euler('ZYX', (np.pi/180)*np.array([0.0, 1.0, 1.0]), degrees=False).as_dcm()
+dOmega = [0, 0, 0]
+initial_state = np.hstack((x0, v0, R0.ravel(), dOmega))
+
+env = QuadrotorHoveringEnv(
+    initial_state=initial_state.astype('float'))
+
+time_step = 0.01
+time_series = np.arange(0, 50, time_step)
+
+obs = env.reset()
+obs_series = np.array([], dtype=np.float64).reshape(0, len(obs))
+ctrl_series = np.array([], dtype=np.float64).reshape(0, 4)
+y_series = np.array([], dtype=np.float64).reshape(0, 3)
+
+pid_roll = PID(1.0 * np.array([1.0, 0.1, 1.0]), windup=False)
+pid_pitch = PID(1.0 * np.array([1.0, 0.1, 1.0]), windup=False)
+pid_height = PID(5 * np.array([1.0, 0.1, 1.0]), windup=10)
+for i in time_series:
+    euler = R.from_dcm(obs[6:15].reshape(3,3)).as_euler('zyx', degrees=False)
+    y = np.concatenate((euler[[2, 1]], -obs[2]), axis=None)
+    y_goal = np.array([0, 0, 0])  # roll, pitch, height
+    e_y = y - y_goal
+    f24_diff = pid_roll.input(e_y[0])
+    f31_diff = pid_pitch.input(e_y[1])
+    quad = Quadrotor(initial_state=initial_state.astype('float'))
+    f1234_sum = pid_height.input(-e_y[2]) + quad.m * quad.g
+    controls = inv(np.array([[0, 1, 0, -1],
+                            [-1, 0, 1, 0],
+                            [1, 1, 1, 1],
+                            [1, -1, 1, -1]])) @ np.transpose(
+                                np.array([f24_diff, f31_diff, f1234_sum, 0]))
+
+    # Need logging here
+    next_obs, reward, done, _ = env.step(controls)
+    # print(obs)
+
+    if done:
+        break
+
+    obs = next_obs
+    obs_series = np.vstack((obs_series, obs))
+    ctrl_series = np.vstack((ctrl_series, controls))
+    y_series = np.vstack((y_series, y))
+
+time_series = time_series[:obs_series.shape[0]]
+
+NED2ENU = np.array([[0, 1, 0],
+                   [1, 0, 0],
+                   [0, 0, -1]])
+data = {'traj': obs_series[:, 0:3] @ NED2ENU, 'input': ctrl_series, 'output': y_series}
+variables = {'traj': ('x', 'y', 'z'), 'input': ('f1', 'f2', 'f3', 'f4'),
+             'output': ('roll', 'pitch', 'height')}
+quantities = {'traj': ('distance', 'distance', 'distance'),
+              'input': ('force', 'force', 'force', 'force'),
+              'output': ('angle', 'angle', 'distance')}
+labels = ('traj', 'input', 'output')
+a = PltModule(time_series, data, variables, quantities)
+a.plot_time(labels)
+a.plot_traj(labels)
+plt.show()


### PR DESCRIPTION
PID 모듈의 유효성을 판단하기 위해 쿼드로터의 inner-loop 에 해당하는 자세 및 고도제어를 수행함.

1. 수정 내용
- 테스트를 위해 `quadrotor_hovering.py` env 작성 (테스트를 위해 간단히 작성되었으므로 사용 시 주의가 요구됨)
- `PID.py` agent 의 수정이 다소 있음
- 테스트를 위해 `main_test_PID.py` main 코드를 작성 및 PID 모듈 검증
2. 결과
![image](https://user-images.githubusercontent.com/43136096/63760966-49ae0a80-c8fb-11e9-9b48-9e61ddcd44c6.png)
![image](https://user-images.githubusercontent.com/43136096/63760985-53d00900-c8fb-11e9-96e8-a7c687b16f5d.png)

자세한 내용은 아래 commit message 참고.

In order to check PID module, env and test main files of quadrotor are
added in advance.
1. How did I perform this test?
Under small angle assumptions, I assumed that each roll, pitch, and
height channel can be decoupled and controlled by 1) f2 - f4 (torque),
 2) f3 - f1 (torque), and 3) total thrust, respectively. So I designed
 simple PID controllers for each channel independently. In addition, to
 resolve the redundant DoF of one, an additional condition was added.
2. To reviewers
Plz check my codes and correct them if there would be something wrong.

Corresponding Issue: (#50)