### PR TITLE
pip를 이용해 fym 모듈 설치가 가능하게 만들었습니다. (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Aerodynamic Simulator for Testing Deep RL Algorithms
 
 [nrf-main](https://github.com/seong-hun/nrf-main)
+
+## Installation
+
+- Clone the repo and change the directory to it
+  ```
+	git clone https://github.com/fdcl-nrf/fym.git
+	cd fym
+	```
+
+- Install the fym package
+	```
+	pip install -e .
+	```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup
+
+setup(
+    name='fym',
+    version='0.2.1',
+    install_requires=['gym', 'matplotlib', 'numdifftools']
+)


### PR DESCRIPTION
Python `setup` 모듈을 이용해서 설치가 가능하게 만들었습니다.
사용법은 `pip install -e .` 로 설치파면 되고 여기서 `-e` 옵션때문에 패키지 내용에 업데이트가 있어도 바로 설치된 `fym` 모듈에 바로 반영이 됩니다. (README.md) 에 반영함)

- 이제 `if __name__ == '__main__':` 이 구문이 들어간 모듈 파일이 프로젝트 루트 디렉터리에서 바로 실행 가능합니다.
   (예: `python fym/models/quadrotor.py`)