### PR TITLE
선형과 모듈 개선(#67)

### DIFF
--- a/fym/utils/linearization.py
+++ b/fym/utils/linearization.py
@@ -2,127 +2,74 @@ import numdifftools as nd
 import numpy as np
 
 
-def jacob_analytic(functions, i):
+def jacob_analytic(function, i=0):
     """
     jacob_analytic is used for obtaining analytic jacobian function
 
     Parameters
     ----------
-    funcions : callable
-        ``functions`` is what we want to get jacobian function.
-        ``functions`` function that takes at least one positional arguments and
-        at most three arguments including positional, arbitrary, keyword args.
-        The order of arguments should be
-        'state', *'control input', *'external input'.
-
-        -``x``: state (`float` or `int`). It must be taken
-        -``u``: control input (`float` or `int`). arbitraty argumnets
-        -``e``: external input (`float` or `int`). arbitraty argumnets
+    funcion : callable
+        ``function`` is what we want to get jacobian function.
     i : int or float
-        ``i`` means what will we get Jacobian function for.
-        0: first arguments of ``functions``(usually x)
-        1: second argument of ``functions``(usually u)
+        ``i`` means i-th argument of ``function`` and
+        what will we get Jacobian function for.
+        for example,
+        if you want to get Jacobian function of ``function`` for first argument
+        of ``function``, set i=0.
 
     Return
     ------
     jacob_fnc : callable
-        jacobian function of ``functions``
+        jacobian function of ``function``
     """
-    if i == 0:
-        jacob_fnc = nd.Jacobian(functions)
-    else:
-        def g(u, x, *e):
-            return functions(x, u, *e)
-        jacob_fnc_temp = nd.Jacobian(g)
+    def new_fun(*argument):
+        argument = list(argument)
+        argument[0], argument[i] = argument[i], argument[0]
+        return function(*argument)
+    jacob_temp = nd.Jacobian(new_fun)
 
-        def jacob_fnc(x, u, *e):
-            return jacob_fnc_temp(u, x, *e)
+    def jacob_fnc(*argument):
+        argument = list(argument)
+        argument[0], argument[i] = argument[i], argument[0]
+        return jacob_temp(*argument)
     return jacob_fnc
 
 
-def jacob_numerical(functions, i, x, *args):
+def jacob_numerical(function, i, *args):
     """
     jacob_numerical is used for obtaining jacobian matrix numerically
 
     Parameters
     ----------
-    funcions : callable
-        ``functions`` is what we want to get jacobian function.
-        ``functions`` function that takes at least one positional arguments and
-        at most three arguments including positional, arbitrary, keyword args.
-        The order of arguments should be
-        'state', *'control input', *'external input'.
-
-        -``x``: state (`float` or `int`). It must be taken
-        -``u``: control input (`float` or `int`). arbitraty argumnets
-        -``e``: external input (`float` or `int`). arbitraty argumnets
+    funcion : callable
+        ``function`` is what we want to get jacobian function.
     i : int or float
-        ``i`` means what will we get Jacobian function for.
-        0: first arguments of ``functions``(usually ``x``)
-        1: second argument of ``functions``(usually ``u``)
-    x : int or float
-        ``x`` is state where we want to get jacobian matrix of ``functions``.
+        ``i`` means i-th argument of ``function`` and
+        what will we get Jacobian function for.
+        for example,
+        if you want to get Jacobian function of ``function`` for first argument
+        of ``function``, set i=0.
     *args : int or float
-        ``*args`` can be 'control input' or 'external input' or both of them.
-        If both 'control input' and 'external input' are included,
-        'control input' must come befor 'exernal input'.
+        Values of ``function``'s arguments which we want to get Jacobian at.
 
     Return
     ------
     dfdx or dfdu: numpy.ndarray
-        jacobian matrix of ``functions`` for ``x``, ``u`` respectively.
+        jacobian matrix of ``functions`` for ``x``, ``u``, respectively,
+        at *args.
     """
     ptrb = 1e-9
-    if len(args) == 2:
-        u = args[0]
-        e = args[1]
-        dx = functions(x, u, e)
-        if i == 0:
-            n = np.size(x)
-            dfdx = np.zeros([n, n])
-            for j in np.arange(n):
-                ptrbvec = np.zeros(n)
-                ptrbvec[j] = ptrb
-                dx_ptrb = functions(x + ptrbvec, u, e)
-                dfdx[j] = (dx_ptrb - dx) / ptrb
-            return np.transpose(dfdx)
-        else:
-            m = np.size(u)
-            dfdu = np.zeros([m, m])
-            for j in np.arange(m):
-                ptrbvec = np.zeros(m)
-                ptrbvec[j] = ptrb
-                dx_ptrb = functions(x, u + ptrbvec, e)
-                dfdu[j] = (dx_ptrb - dx) / ptrb
-            return np.transpose(dfdu)
-    elif len(args) == 1:
-        u = args[0]
-        dx = functions(x, u)
-        if i == 0:
-            n = np.size(x)
-            dfdx = np.zeros([n, n])
-            for j in np.arange(n):
-                ptrbvec = np.zeros(n)
-                ptrbvec[j] = ptrb
-                dx_ptrb = functions(x + ptrbvec, u)
-                dfdx[j] = (dx_ptrb - dx) / ptrb
-            return np.transpose(dfdx)
-        else:
-            m = np.size(u)
-            dfdu = np.zeros([m, m])
-            for j in np.arange(m):
-                ptrbvec = np.zeros(m)
-                ptrbvec[j] = ptrb
-                dx_ptrb = functions(x, u + ptrbvec)
-                dfdu[j] = (dx_ptrb - dx) / ptrb
-            return np.transpose(dfdu)
-    else:
-        dx = functions(x)
-        n = np.size(x)
-        dfdx = np.zeros([n, n])
-        for j in np.arange(n):
-            ptrbvec = np.zeros(n)
-            ptrbvec[j] = ptrb
-            dx_ptrb = functions(x + ptrbvec)
-            dfdx[j] = (dx_ptrb - dx) / ptrb
-        return np.transpose(dfdx)
+    n = np.size(args[i])
+    dx = function(*args)
+    dfdx = np.zeros([n, n])
+    args_save = args[i]
+    for j in np.arange(n):
+        args = list(args)
+        ptrbvec = np.zeros(n)
+        ptrbvec[j] = ptrb
+        args[i] = args[i] + ptrbvec
+        dx_ptrb = function(*args)
+        dfdx[j] = (dx_ptrb - dx) / ptrb
+        args[i] = args_save
+
+    return np.transpose(dfdx)


### PR DESCRIPTION
예전엔 함수의 input order가 어느정도 정해져 있어야 했다.(첫 번째 input은 무조건 state여야 했으며 control, external, time등이 오면 셋 중엔 control이 무조건 먼저 와야 했다.)

이젠 function의 input arguments 순서를 자유롭게 만들어도 되며 선형화할 때 function의 몇 번째 argument로 자코비안을 구할 것인지 정해주면 된다.


before
Function which user wants to linearize have to observe the order of
input arguments.
after
The function have not to observe the order of input arguments.
User just determine which numberth of input arguments the function
should be linearized about