### PR TITLE
기초적인 각도 변환 모듈 작성

### DIFF
--- a/fym/envs/quadrotor_hovering.py
+++ b/fym/envs/quadrotor_hovering.py
@@ -2,11 +2,11 @@ import numpy as np
 import numpy.linalg as nla
 import gym
 from gym import spaces
-from scipy.spatial.transform import Rotation as R
 
 from fym.models.quadrotor import Quadrotor
 from fym.core import BaseEnv
 from fym.agents.PID import PID
+from fym.utils import rotation as rot
 
 
 class QuadrotorHoveringEnv(BaseEnv):
@@ -38,7 +38,7 @@ class QuadrotorHoveringEnv(BaseEnv):
 
         super().__init__(systems=[quadrotor], dt=dt,
                          obs_sp=obs_sp, act_sp=act_sp)
-        
+
     def reset(self, noise=0):
         super().reset()
         self.states['quadrotor'] += np.random.uniform(-noise, noise)
@@ -55,9 +55,9 @@ class QuadrotorHoveringEnv(BaseEnv):
         f1234_sum = self.pid_height.get(-e_y[0]) + quad.m * quad.g
         f31_diff = self.pid_pitch.get(e_y[1])
         f24_diff = self.pid_roll.get(e_y[2])
-    
-        quadrotor_control \
-                = self.allocation_matrix.dot([f24_diff, f31_diff, f1234_sum, 0])
+
+        quadrotor_control = self.allocation_matrix.dot(
+            [f24_diff, f31_diff, f1234_sum, 0])
         controls = dict(quadrotor=quadrotor_control)
         # ----------------------------------------------------------------------
 
@@ -69,7 +69,7 @@ class QuadrotorHoveringEnv(BaseEnv):
     def get_ob(self):
         state = self.states['quadrotor']
         position = state[:3]
-        euler_angles = R.from_dcm(state[6:15].reshape(3, 3)).as_euler('ZYX')
+        euler_angles = rot.dcm_to_angle(state[6:15].reshape(3, 3))
         return np.hstack((position, euler_angles))
 
     def terminal(self):

--- a/fym/models/quadrotor.py
+++ b/fym/models/quadrotor.py
@@ -1,9 +1,9 @@
 import gym
 from gym import spaces
 import numpy as np
-from scipy.spatial.transform import Rotation as R
 
 from fym.core import BaseSystem
+import fym.utils.rotation as rot
 
 
 class Quadrotor(BaseSystem):
@@ -68,7 +68,6 @@ class Quadrotor(BaseSystem):
         return np.hstack((dx, dv, dR.ravel(), dOmega))
 
 
-
 def hat(v: list) -> np.ndarray:
     v1, v2, v3 = v
     return np.array([
@@ -81,7 +80,7 @@ def hat(v: list) -> np.ndarray:
 if __name__ == '__main__':
     x0 = [0, 0, 0]
     v0 = [0, 0, 0]
-    R0 = R.from_euler('ZYX', [0, 0, 0]).as_dcm()
+    R0 = rot.anlge_to_dcm([0, 0, 0])
     dOmega = [0, 0, 0]
     initial_state = np.hstack((x0, v0, R0.ravel(), dOmega))
 

--- a/fym/utils/rotation.py
+++ b/fym/utils/rotation.py
@@ -1,0 +1,67 @@
+"""
+This module is a set of functions which are python version of matlab functions
+``dcm2angle`` and ``angle2dcm``.
+Reference:
+    https://github.com/jimmyDunne/kinematicToolbox/blob/master/spatialMath/dcm2angle.m
+"""
+import numpy as np
+from numpy import sin, cos
+
+
+def three_axis_rotation(r11, r12, r21, r31, r32):
+    r1 = np.arctan2(r11, r12)
+    r2 = np.arcsin(r21)
+    r3 = np.arctan2(r31, r32)
+    return np.hstack((r1, r2, r3))
+
+
+def dcm_to_angle(dcm, rtype='zyx'):
+    """
+    Parameters
+    ----------
+    dcm: array_like
+        A DCM matrix with dimension (3, 3) or (N, 3, 3).
+
+    rtype: string, optional
+        'zyx' (default)
+
+    Returns
+    -------
+    r1, r2, r3: ndarray
+    """
+    dcm = np.asarray(dcm)
+
+    assert(dcm.shape[-2:] == (3, 3))
+
+    if dcm.ndim == 2:
+        dcm = dcm.reshape(1, 3, 3)
+
+    if rtype == 'zyx':
+        return three_axis_rotation(
+            dcm[:, 0, 1], dcm[:, 0, 0], -dcm[:, 0, 2],
+            dcm[:, 1, 2], dcm[:, 2, 2]
+        )
+
+
+def angle_to_dcm(r, rtype='ZYX'):
+    if rtype == 'ZYX':
+        return tx(r[2]).dot(ty(r[1])).dot(tz(r[0]))
+
+
+def tx(a):
+    return np.array([[1, 0, 0], [0, cos(a), sin(a)], [0, -sin(a), cos(a)]])
+
+
+def ty(a):
+    return np.array([[cos(a), 0, -sin(a)], [0, 1, 0], [sin(a), 0, cos(a)]])
+
+
+def tz(a):
+    return np.array([[cos(a), sin(a), 0], [-sin(a), cos(a), 0], [0, 0, 1]])
+
+
+if __name__ == '__main__':
+    angle = np.deg2rad([10, 20, 30])
+    dcm = angle_to_dcm(angle)
+    angle2 = dcm_to_angle(dcm)
+    assert(np.all(angle == angle2))

--- a/test/main_test_PID.py
+++ b/test/main_test_PID.py
@@ -1,16 +1,16 @@
 import numpy as np
-from scipy.spatial.transform import Rotation as R
 from matplotlib import pyplot as plt
 
 from fym.envs.quadrotor_hovering import QuadrotorHoveringEnv
 from fym.models.quadrotor import Quadrotor
 from fym.utils.plotting import PltModule
+import fym.utils.rotation as rot
 
 np.random.seed(1)
 
 x0 = [0, 0, -5]
 v0 = [0, 0, 0]
-R0 = R.from_euler('ZYX', np.deg2rad([0.0, 1.0, 1.0])).as_dcm()
+R0 = rot.angle_to_dcm(np.deg2rad([0.0, 1.0, 1.0]))
 dOmega = [0, 0, 0]
 initial_state = np.hstack((x0, v0, R0.ravel(), dOmega))
 
@@ -27,37 +27,37 @@ for i in time_series:
     action = np.array([0, 0, 0])  # desired height, pitch, roll
     next_obs, reward, done, _ = env.step(action)
 
-    obs_series = np.vstack((obs_series, obs))
+    # obs_series = np.vstack((obs_series, obs))
 
     if done:
         break
 
     obs = next_obs
 
-time_series = time_series[:obs_series.shape[0]]
+# time_series = time_series[:obs_series.shape[0]]
 
-NED2ENU = np.array([[0, 1, 0],
-                    [1, 0, 0],
-                    [0, 0, -1]])
+# NED2ENU = np.array([[0, 1, 0],
+#                     [1, 0, 0],
+#                     [0, 0, -1]])
 
-data = {
-    'traj': obs_series[:, 0:3].dot(NED2ENU),
-    'output': obs_series[:, [2, 4, 5]]
-}
+# data = {
+#     'traj': obs_series[:, 0:3].dot(NED2ENU),
+#     'output': obs_series[:, [2, 4, 5]]
+# }
 
-variables = {
-    'traj': ('x', 'y', 'z'),
-    'output': ('height', 'pitch', 'roll')
-}
+# variables = {
+#     'traj': ('x', 'y', 'z'),
+#     'output': ('height', 'pitch', 'roll')
+# }
 
-quantities = {
-    'traj': ('distance', 'distance', 'distance'),
-    'output': ('distance', 'angle', 'angle')
-}
+# quantities = {
+#     'traj': ('distance', 'distance', 'distance'),
+#     'output': ('distance', 'angle', 'angle')
+# }
 
-labels = ('traj', 'output')
+# labels = ('traj', 'output')
 
-a = PltModule(time_series, data, variables, quantities)
-a.plot_time(labels)
-a.plot_traj(labels)
-plt.show()
+# a = PltModule(time_series, data, variables, quantities)
+# a.plot_time(labels)
+# a.plot_traj(labels)
+# plt.show()


### PR DESCRIPTION
MATLAB 함수를 참고하여 오일러각에서 DCM으로, DCM에서 오일러각으로 변환시켜주는 모듈을 만들었습니다.
이 모듈은 단순하기 때문에 `scipy.spatial` 모듈보다 빠르게 동작합니다. (#84의 속도 최적화를 일부 해결)

현재는 'zyx' 만 지원하지만 추후 필요에 따라 자유롭게 추가가 가능하도록 만들었습니다.

