### PR TITLE
Improve core

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -1,98 +1,125 @@
 from collections import OrderedDict
+import functools
 import numpy as np
+from scipy.integrate import odeint
 import gym
 
 
+def infer_obs_space(systems):
+    """
+    Infer the gym observation space from the ordered dictionary ``systems``,
+    and return a gym.spaces.Dict
+    """
+    obs_space = gym.spaces.Dict(
+        {k: infinite_box(s.state_shape) for k, s in systems.items()})
+    return obs_space
+
+
 class BaseEnv(gym.Env):
-    def __init__(self, systems: list, dt: float,
-                 obs_sp: gym.spaces.Space, act_sp: gym.spaces.Space,
-                 rk4_steps: int=2):
+    def __init__(self, systems: list, dt: float, infer_obs_space=True):
         self.systems = OrderedDict({s.name: s for s in systems})
-        self.state_index = np.cumsum([system.state_size for system in systems])
-        self.control_index = np.cumsum([system.control_size for system in systems])
+
+        if infer_obs_space and not hasattr(self, 'observation_space'):
+            self.observation_space = self.infer_obs_space(self.systems)
+
+        # Indices for packing
+        self.state_index = [system.state_shape for system in systems]
+        self.control_index = [system.control_shape for system in systems]
 
         # Necessary properties for gym.Env
-        self.observation_space = obs_sp
-        self.action_space = act_sp
+        if not hasattr(self, 'observation_space'):
+            raise NotImplementedError('The observation_space is not defined.')
 
-        self.rk4_steps = rk4_steps
-        self.dt = dt
+        if not hasattr(self, 'action_space'):
+            raise NotImplementedError('The action_space is not defined.')
+
+        self.clock = Clock(dt=dt)
 
     def reset(self):
         initial_states = {
             k: system.reset() for k, system in self.systems.items()
         }
         self.states = initial_states
-        self.clock = 0
+        self.clock.reset()
         return self.get_ob()
 
-    def step(self, controls):
+    def step(self, action):
         xs = np.hstack(list(self.states.values()))
-        us = np.hstack(list(controls.values()))
-        t = self.clock
+        t_span = self.clock + np.array([0, self.dt])
 
-        nxs = rk4(
-            self.derivs,
-            xs,
-            t + np.linspace(0, self.dt, self.rk4_steps), us
-        )
+        func = self.ode_wrapper(self.derivs, args=(action,))
+        nxs = odeint(func, t_span, xs, tfirst=True, **self.ode_args)
 
         nxs = nxs[-1]
-        next_states = self.resolve(nxs, self.state_index)
+        next_states = self.pack_state(nxs)
 
         # Reward and terminal
-
-        reward = self.get_reward(controls)
+        reward = self.reward()
         terminal = self.terminal()
 
         # Update internal state and clock
         self.states = next_states
-        self.clock = t + self.dt
+        self.clock = t_span[-1]
 
-        return (self.get_ob(), reward, terminal, {})
+        return (self.observation(next_states), reward, terminal, {})
 
-    def get_reward(self, controls: dict) -> float:
-        raise NotImplementedError("Reward function is not defined in the Env.")
+    def ode_wrapper(self, func, args):
+        @functools.wraps
+        def wrapper(t, y):
+            states = self.pack_state(y)
+            return func(t, states, *args)
+        return wrapper
 
-    def terminal(self) -> bool:
-        raise NotImplementedError("Terminal is not defined in the Env.")
+    def derivs(self, t, states, action):
+        """
+        It is recommened to override this method by a user-defined ``derivs``.
+        """
+        controls = self.pack_action(us, self.control_index)
+        derivs = [system.deriv(t, states, controls) for system in self.systems]
+        return np.hstack(derivs)
 
-    def get_ob(self) -> np.ndarray:
-        raise NotImplementedError("Observation is not defined in the Env.")
+    def pack_state(self, flat_state):
+        unpacked = OrderedDict(
+            zip(self.systems.keys(), pack(flat_state, self.state_index)))
+        return unpacked
+
+    def pack_action(self, action):
+        unpacked = OrderedDict(
+            zip(self.systems.keys(), pack(action, self.control_index)))
+        return unpacked
 
     def resolve(self, ss, index):
         *ss, _ = np.split(ss, index)
         some = OrderedDict(zip(self.systems.keys(), ss))
         return some
 
-    def derivs(self, xs, t, us):
-        """
-        Returns:
-            *xs*: ndarray
-                An array of aggregated states.
-            *t*: float
-                The time when the derivatives calculated.
-            *us*: ndarray
-                An array of aggregated control inputs.
-        """
-        states = self.resolve(xs, self.state_index)
-        controls = self.resolve(us, self.control_index)
+    def reward(self, controls: dict) -> float:
+        raise NotImplementedError("Reward function is not defined in the Env.")
 
-        derivs = []
-        for s, x, u in zip(*map(dict.values, [self.systems, states, controls])):
-            derivs.append(s.deriv(x, t, u, s.external(states, controls)))
+    def terminal(self) -> bool:
+        raise NotImplementedError("Terminal is not defined in the Env.")
 
-        return np.hstack(derivs)
+    def observation(self, observation):
+        raise NotImplementedError
 
 
 class BaseSystem:
     def __init__(self, name, initial_state, control_size=0, deriv=None):
         self.name = name
         self.initial_state = initial_state
-        self.state_size = len(initial_state)
+        self.state_shape = self.initial_state.shape()
         self.control_size = control_size
+
         if callable(deriv):
             self.deriv = deriv
+
+    @property
+    def initial_state(self):
+        return _initial_state
+
+    @initial_state.setter
+    def initial_state(self, val):
+        self._initial_stat = np.asarray(val)
 
     def deriv(self, state, t, control, external):
         raise NotImplementedError("deriv method is not defined in the system.")
@@ -101,63 +128,31 @@ class BaseSystem:
         return self.initial_state
 
 
-def rk4(derivs, y0, t, *args, **kwargs):
+class Clock:
+    def __init__(self, dt, max_t=None):
+        self.dt = dt
+
+    def reset(self):
+        self.t = 0
+
+    def tick(self):
+        self.t += self.dt
+
+    def get(self):
+        return self.t
+
+
+def pack(flat_state, indices):
     """
-    Integrate 1D or ND system of ODEs using 4-th order Runge-Kutta.
-    This is a toy implementation which may be useful if you find
-    yourself stranded on a system w/o scipy.  Otherwise use
-    :func:`scipy.integrate`.
-    *y0*
-        initial state vector
-    *t*
-        sample times
-    *derivs*
-        returns the derivative of the system and has the
-        signature ``dy = derivs(yi, ti)``
-    *args*
-        additional arguments passed to the derivative function
-    *kwargs*
-        additional keyword arguments passed to the derivative function
-    Example 1 ::
-        ## 2D system
-        def derivs6(x,t):
-            d1 =  x[0] + 2*x[1]
-            d2 =  -3*x[0] + 4*x[1]
-            return (d1, d2)
-        dt = 0.0005
-        t = arange(0.0, 2.0, dt)
-        y0 = (1,2)
-        yout = rk4(derivs6, y0, t)
-    Example 2::
-        ## 1D system
-        alpha = 2
-        def derivs(x,t):
-            return -alpha*x + exp(-t)
-        y0 = 1
-        yout = rk4(derivs, y0, t)
-    If you have access to scipy, you should probably be using the
-    scipy.integrate tools rather than this function.
+    Pack states from the flattened state using ``indices``.
+    The ``indices`` is a list or a tuple which must have the equal length
+    to the ``flat_state``.
     """
+    div_points = [0] + np.cumsum(
+        [np.prod(index) for index in indices]).tolist()
 
-    try:
-        Ny = len(y0)
-    except TypeError:
-        yout = np.zeros((len(t),), np.float_)
-    else:
-        yout = np.zeros((len(t), Ny), np.float_)
-
-    yout[0] = y0
-
-    for i in np.arange(len(t) - 1):
-
-        thist = t[i]
-        dt = t[i + 1] - thist
-        dt2 = dt / 2.0
-        y0 = yout[i]
-
-        k1 = np.asarray(derivs(y0, thist, *args, **kwargs))
-        k2 = np.asarray(derivs(y0 + dt2 * k1, thist + dt2, *args, **kwargs))
-        k3 = np.asarray(derivs(y0 + dt2 * k2, thist + dt2, *args, **kwargs))
-        k4 = np.asarray(derivs(y0 + dt * k3, thist + dt, *args, **kwargs))
-        yout[i + 1] = y0 + dt / 6.0 * (k1 + 2 * k2 + 2 * k3 + k4)
-    return yout
+    packed = []
+    for i in range(len(indices)):
+        packed.append(
+            flat_state[div_points[i]:div_points[i+1]].reshape(indices[i]))
+    return packed


### PR DESCRIPTION
core.py 의 전반적인 개선을 했습니다.

- 이제 `observation_space` 를 `systems`의 초기값으로부터 자동으로 추측하게 할 수 있습니다.
- `BaseEnv.__init__`의 불필요한 `obs_space`, `action_space` 인자들을 제거했습니다,
- 적분이 이제 `scipy`의 포트란 코드로 동작합니다 (간단한 실험결과 2배 이상 속도 향상, #84 )
- `Clock` 클래스를 만들어 여러 루프의 시뮬레이션 관리가 수월해졌습니다.
- `BaseSystem.deriv` 대신 `BaseEnv.derivs`로 여러 시스템들 간의 상호작용 코드를 짜기 편해졌습니다.


## Improve the core.py

- Infer the `observation_space` based on `systems`.
- Remove the `obs_space` and `obs_space` arguments in `__init__` method,
  and replace it with attribute checking statements.
- Integration improved. Now the integrator uses
  `scipy.integrate.odeint` (#84).
- Add Clock class which helps us manage the iteration time, episode
  number, etc, more intuitively and clearly.
- Remove the need of `BaseSystem.deriv` and replace it with
  `BaseEnv.derivs`. This is more clear when we design the environment
  of which systems are interacting in very complex way.

## Add packing and unpacking functions

- State dictionary can now be flattened with unpacking function
- State list of numpy arrays can now be packed with packing function