### PR TITLE
Create a data logger

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -6,6 +6,8 @@ import numpy as np
 from scipy.integrate import odeint
 import gym
 
+from fym.utils import logger
+
 
 def deep_flatten(arg):
     if arg == []:
@@ -54,6 +56,8 @@ class BaseEnv(gym.Env):
 
         self.clock = Clock(dt=dt)
 
+        self.logger = logger.Logger(flename='state_history.h5')
+
         self.odeint_option = odeint_option
 
         if not isinstance(ode_step_len, int):
@@ -79,8 +83,9 @@ class BaseEnv(gym.Env):
         packed_hist = [self.pack_state(_) for _ in ode_hist]
         next_states = packed_hist[-1]
 
-        nxs = nxs[-1]
-        next_states = self.pack_state(nxs)
+        # Log the inner history of states
+        for t, s in zip(t_span[:-1], packed_hist[:-1]):
+            self.logger.log_dict(t, state=s, action=action)
 
         return next_states, packed_hist
 

--- a/fym/core.py
+++ b/fym/core.py
@@ -56,9 +56,7 @@ class BaseEnv(gym.Env):
             raise NotImplementedError('The action_space is not defined.')
 
         self.clock = Clock(dt=dt, max_t=max_t)
-
         self.logger = logger.Logger(file_name=file_name)
-
         self.odeint_option = odeint_option
 
         if not isinstance(ode_step_len, int):
@@ -86,7 +84,7 @@ class BaseEnv(gym.Env):
 
         # Log the inner history of states
         for t, s in zip(t_span[:-1], packed_hist[:-1]):
-            self.logger.log_dict(t=t, state=s, action=action)
+            self.logger.log_dict(time=t, state=s, action=action)
 
         return next_states, packed_hist
 

--- a/fym/utils/logger.py
+++ b/fym/utils/logger.py
@@ -67,9 +67,6 @@ class Logger:
         os.makedirs(log_dir, exist_ok=True)
         self.path = os.path.join(log_dir, file_name)
 
-        if os.path.exists(self.path):
-            os.remove(self.path)
-
         self.f = h5py.File(self.path, 'w')
         self.max_len = max_len
         self.reset()

--- a/fym/utils/logger.py
+++ b/fym/utils/logger.py
@@ -1,0 +1,126 @@
+import h5py
+import numpy as np
+import os
+from datetime import datetime
+
+
+def save_dict_to_hdf5(h5file, dic):
+    recursively_save(h5file, '/', dic)
+
+
+def recursively_save(h5file, path, dic):
+    for key, val in dic.items():
+        if isinstance(val, (np.ndarray, list)):
+            val = np.stack(val)
+            if path + key not in h5file:
+                dset = h5file.create_dataset(
+                    path + key,
+                    shape=val.shape,
+                    maxshape=(None,) + val.shape[1:],
+                    dtype=float,
+                )
+                dset[:] = val
+            else:
+                dset = h5file[path + key]
+                dset.resize(dset.shape[0] + len(val), axis=0)
+                dset[-len(val):] = val
+        elif isinstance(val, dict):
+            recursively_save(h5file, path + key + '/', val)
+        else:
+            raise ValueError(f'Cannot save {type(val)} type')
+
+
+def load_dict_from_hdf5(filename):
+    with h5py.File(filename, 'r') as h5file:
+        return recursively_load_dict_contents_from_group(h5file, '/')
+
+
+def recursively_load_dict_contents_from_group(h5file, path):
+    ans = {}
+    for key, item in h5file[path].items():
+        if isinstance(item, h5py._hl.dataset.Dataset):
+            ans[key] = item[()]
+        elif isinstance(item, h5py._hl.group.Group):
+            ans[key] = recursively_load_dict_contents_from_group(
+                h5file, path + key + '/')
+    return ans
+
+
+def recursively_update_dict(base_dict, input_dict):
+    for key, val in input_dict.items():
+        if isinstance(val, dict):
+            recursively_update_dict(base_dict.setdefault(key, {}), val)
+        elif not isinstance(val, str):
+            base_dict.setdefault(key, []).append(val)
+        else:
+            raise ValueError("Unsupported data type")
+
+
+class Logger:
+    def __init__(self, file_name, max_len=1e2, log_dir=None):
+        if log_dir is None:
+            log_dir = os.path.join(
+                'log',
+                datetime.today().strftime('%Y%m%d-%H%M%S')
+            )
+
+        os.makedirs(log_dir, exist_ok=True)
+        self.path = os.path.join(log_dir, file_name)
+
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+        self.f = h5py.File(self.path, 'w')
+        self.max_len = max_len
+        self.reset()
+
+    def reset(self):
+        self.buffer = {}
+        self.len = 0
+
+    def log_dict(self, **kwargs):
+        recursively_update_dict(self.buffer, kwargs)
+        self.len += 1
+
+        if self.len >= self.max_len:
+            save_dict_to_hdf5(self.f, self.buffer)
+            self.reset()
+
+    def close(self):
+        self.f.close()
+
+
+if __name__ == '__main__':
+    logger = Logger('sample', max_len=5)
+
+    data = {
+        'state': {
+            'main_system': np.array([0., 0., 0., 0.]),
+            'reference_system': np.array([1., 1., 1., 1.]),
+            'adaptive_system': np.array([
+                [2., 2.],
+                [2., 2.],
+                [2., 2.],
+                [2., 2.],
+                [2., 2.]])
+        },
+        'action': {
+            'M': np.array([
+                [1., 1., 1., 1., 1.],
+                [1., 1., 1., 1., 1.],
+                [1., 1., 1., 1., 1.],
+                [1., 1., 1., 1., 1.],
+                [1., 1., 1., 1., 1.]]),
+            'N': np.array([
+                [0., 0., 0., 0., 0.],
+                [0., 0., 0., 0., 0.],
+                [0., 0., 0., 0., 0.],
+                [0., 0., 0., 0., 0.],
+                [0., 0., 0., 0., 0.]])
+        }
+    }
+
+    for _ in range(10):
+        logger.log_dict(**data)
+
+    logger.close()


### PR DESCRIPTION
데이터 로거 모듈을 만들었습니다. (관련 이슈: #53, #45)

- 이제 `BaseEnv` 가 자동으로 state 히스토리를 log 파일에 저장합니다. (기본값: `log/<yyyymmdd-hhmmss>/state_history.h5`)
- 로거는 기본적으로 내부 버퍼에 딕셔너리 형태로 로깅을 합니다. (`Logger.log_dict` 메서드 이용)
- 내부 버퍼 크기가 `Logger.max_len`에 도달하면 log 파일에 append 하고 내부 버퍼를 비웁니다.
- 이 로거는 `BaseEnv` 뿐만 아니라 다른 외부 환경에서도 이용가능합니다.


- Related issues: #53, #45
- Now a BaseEnv logs the internal state history automatically to a
  log directory (default: `log/<yyyymmdd-hhmmss>/state_history.h5`)
- The logger store dictionary-like values in the local buffer, and
  whenever the buffer length get bigger than a `max_len`, the data is
  dumped (appended) to the hdf5 file.