### PR TITLE
Improve speed

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -114,11 +114,6 @@ class BaseEnv(gym.Env):
         """
         raise NotImplementedError
 
-    def pack_state(self, flat_state):
-        packed = dict(
-            zip(self.systems.keys(), pack(flat_state, self.state_index)))
-        return packed
-
     def append_systems(self, systems):
         self.systems.update(systems)
         self.indexing()
@@ -130,16 +125,6 @@ class BaseEnv(gym.Env):
     def close(self):
         if not self.logging_off:
             self.logger.close()
-
-    def unpack_state(self, states):
-        if isinstance(states, (list, np.ndarray)):
-            if np.ndim(states) != 1:
-                states = flatten(states)
-
-        elif isinstance(states, dict):
-            states = flatten(states.values())
-
-        return np.hstack(states)
 
     def render(self, mode="tqdm"):
         if mode == "tqdm":
@@ -215,23 +200,6 @@ def pack(flat_state, indices):
             flat_state[tmp:tmp + mult].reshape(index)
         )
         tmp += mult
-    """
-    > timeit: 3.74 micro
-    """
-
-    """
-    div_points = [0] + list(itertools.accumulate(
-        [functools.reduce(lambda a, b: a * b, i) for i in indices],
-    ))
-
-    packed = [
-        flat_state[div_points[i]:div_points[i+1]].reshape(indices[i])
-        for i in range(len(indices))
-    ]
-    """
-    """
-    > timeit: 5.22 micro
-    """
 
     return packed
 
@@ -243,10 +211,6 @@ def deep_flatten(arg):
         return deep_flatten(arg[0]) + deep_flatten(arg[1:])
     elif isinstance(arg, (np.ndarray, float, int)):
         return [np.asarray(arg).ravel()]
-
-
-def flatten(arglist):
-    return [np.asarray(arg).ravel() for arg in arglist]
 
 
 def infinite_box(shape):

--- a/test/figures.py
+++ b/test/figures.py
@@ -1,0 +1,106 @@
+import sys
+import os
+import glob
+import numpy as np
+import matplotlib.pyplot as plt
+from cycler import cycler
+
+import fym.logging as logging
+
+
+BASE_DATA_DIR = "data"
+
+plt.rc("font", **{
+    "family": "sans-serif",
+    # "sans-serif": ["Helvetica"],
+})
+# plt.rc("text", usetex=True)
+plt.rc("lines", linewidth=1.3)
+plt.rc("axes", grid=True)
+plt.rc("grid", linestyle="--", alpha=0.8)
+
+
+canvas = []
+fig, axes = plt.subplots(2, 1, sharex=True)
+axes[0].set_ylabel(r"$\beta$ [deg]")
+axes[1].set_ylabel(r"$r$ [deg/sec]")
+axes[1].set_xlabel("Time [sec]")
+canvas.append((fig, axes))
+
+fig, axes = plt.subplots(2, 1, sharex=True)
+axes[0].set_ylabel(r"$\phi$ [deg]")
+axes[1].set_ylabel(r"$p$ [deg/sec]")
+axes[1].set_xlabel("Time [sec]")
+canvas.append((fig, axes))
+
+# fig, axes = plt.subplots(2, 1, sharex=True)
+# axes[0].set_ylabel(r"$\delta_a$ [deg]")
+# axes[1].set_ylabel(r"$\delta_r$ [deg]")
+# axes[1].set_xlabel("Time [sec]")
+# canvas.append((fig, axes))
+
+
+def get_data(exp, prefix=BASE_DATA_DIR):
+    path = os.path.join(prefix, exp + ".h5")
+    return logging.load(path)
+
+
+def plot_single(data, color="k", name=None):
+    time = data["time"]
+    beta, phi, p, r = data["state"]["main"][:, :4].T
+    # aileron, rudder = data["control"].T
+
+    canvas[0][1][0].plot(time, beta, color=color, label=name)
+    canvas[0][1][1].plot(time, r, color=color)
+
+    canvas[1][1][0].plot(time, phi, color=color, label=name)
+    canvas[1][1][1].plot(time, p, color=color)
+
+    # canvas[2][1][0].plot(time, aileron, color=color, label=name)
+    # canvas[2][1][1].plot(time, rudder, color=color)
+
+
+def plot_mult(dataset, color_cycle=None, names=None):
+    if color_cycle is None:
+        color_cycle = cycler(
+            color=plt.rcParams["axes.prop_cycle"].by_key()["color"]
+        )
+
+    if names is not None:
+        for data, color, name in zip(dataset, color_cycle(), names):
+            plot_single(data, color=color["color"], name=name)
+
+        for fig, axes in canvas:
+            axes[0].legend(*axes[0].get_legend_handles_labels())
+    else:
+        for data, color in zip(dataset, color_cycle()):
+            plot_single(data, color=color["color"])
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", nargs="*")
+    parser.add_argument("--all", action="store_true")
+    args = parser.parse_args()
+
+    color_cycle = cycler(color=plt.rcParams["axes.prop_cycle"].by_key()["color"])
+
+    path_list = args.file
+    if args.all:
+        path_list = sorted(glob.glob(os.path.join(BASE_DATA_DIR, "*.h5")))
+    else:
+        path_list = sorted(filter(lambda x: x.endswith(".h5"), path_list))
+
+    dataset = []
+    for path, c in zip(path_list, color_cycle()):
+        dataset.append(logging.load(path))
+
+    names = [os.path.basename(os.path.splitext(path)[0]) for path in path_list]
+
+    print("Plotting ...")
+    print("\n".join(path_list))
+    plot_mult(dataset, color_cycle, names=names)

--- a/test/performance_compare.py
+++ b/test/performance_compare.py
@@ -90,20 +90,12 @@ class OriginalEnv(core.BaseEnv):
         return self.observation(), 0, done, info
 
     def derivs(self, time, action):
-        x1, x2 = [system.state for system in self.systems.values()]
         u1, u2 = action[:2], action[2:]
 
         main = self.systems["main"]
         aux = self.systems["aux"]
-        main.dot = main.deriv(x1, u1)
-        aux.dot = aux.deriv(x2, u2)
-
-        # x, y = [self.states[ind] for ind in self.index.values()]
-        # x = self.states[self.index["main"]]
-
-        # states_dot = np.zeros_like(self.states)
-        # states_dot[self.index["main"]] = self.main.deriv(x, action)
-        # return states_dot
+        main.dot = main.deriv(main.state, u1)
+        aux.dot = aux.deriv(aux.state, u2)
 
 
 class Lqr:

--- a/test/validation.py
+++ b/test/validation.py
@@ -1,0 +1,103 @@
+import numpy as np
+from scipy.integrate import odeint
+import time
+
+import fym
+import fym.core as core
+import fym.models.aircraft as aircraft
+from fym.agents.LQR import clqr
+
+
+class OriginalEnv(core.BaseEnv):
+    def __init__(self, logging_off=False):
+        super().__init__(
+            systems={
+                "main": aircraft.F16LinearLateral(),
+                "aux": aircraft.F16LinearLateral(),
+            },
+            dt=0.01,
+            max_t=10,
+            logging_off=logging_off,
+        )
+
+    def reset(self):
+        super().reset()
+        return self.observation()
+
+    def observation(self):
+        return self.observe_flat()
+
+    def step(self, action):
+        done = self.clock.time_over()
+        info = {
+            "states": self.observe_dict()
+        }
+        self.update(action)
+        return self.observation(), 0, done, info
+
+    def derivs(self, time, action):
+        x1, x2 = [system.state for system in self.systems.values()]
+        u1, u2 = action[:2], action[2:]
+
+        main = self.systems["main"]
+        aux = self.systems["aux"]
+        main.dot = main.deriv(x1, u1)
+        aux.dot = aux.deriv(x2, u2)
+
+        # x, y = [self.states[ind] for ind in self.index.values()]
+        # x = self.states[self.index["main"]]
+
+        # states_dot = np.zeros_like(self.states)
+        # states_dot[self.index["main"]] = self.main.deriv(x, action)
+        # return states_dot
+
+
+class Lqr:
+    Q = np.diag([50, 100, 100, 50, 0, 0, 1])
+    R = np.diag([0.1, 0.1])
+
+    def __init__(self, sys):
+        self.K = clqr(sys.A, sys.B, self.Q, self.R)[0]
+
+    def get_action(self, x):
+        x1, x2 = x[:7], x[7:]
+        return np.hstack([-self.K.dot(x1), -self.K.dot(x2)])
+
+
+def run(env, agent=None, number=1, text=""):
+    t0 = time.time()
+    for _ in range(number):
+        obs = env.reset()
+        while True:
+            if agent is None:
+                action = 0
+            else:
+                action = agent.get_action(obs)
+
+            next_obs, _, done, _ = env.step(action)
+            obs = next_obs
+
+            if done:
+                break
+
+    t1 = time.time()
+
+    env.close()
+
+    print("\t".join([
+        f"{text}:",
+        f"{number} Runs,",
+        f"Total: {t1 - t0:.4} sec",
+    ]))
+
+    return t1 - t0
+
+
+def test_validate():
+    env = OriginalEnv()
+    agent = Lqr(env.systems["main"])
+    run(env, agent, 1, "Original Env (logging on)")
+
+
+if __name__ == "__main__":
+    test_validate()


### PR DESCRIPTION
v0.4 의 첫번째 풀리퀘입니다.
적분 속도향상을 위해 전반적인 메커니즘과 API 를 수정했습니다.
사용 예제는 `test/performance_compare.py` 를 보시면 됩니다.

### 메커니즘 수정사항
- `BaseEnv`는 이제 `dict` 를 state 로 들고다니지 않습니다. 대신 각 state 들은 `ndarray` 타입으로 각 `BaseSystem` 에 저장되고, 매 적분시 업데이트 됩니다. 이 방식으로 인해 굳이 다시 `dict` 로 pack / unpack 하는 불필요한 과정이 줄어 적분속도가 7배 향상되었습니다.

### API 수정사항
- `BaseEnv.reset` 메소드는 이제 아무 값도 리턴하지 않습니다. 대신 `BaseEnv` 내의 등록된 모든 `BaseSystem` 들의 state 를 `BaseSystem.initial_state` 로 업데이트 합니다. 따라서 RL을 위해 `reset` 을 새로 정의해야 합니다. 이는 `BaseEnv` 를 기반으로 사용자가 직접 `Env`를 구성할 때 기본적으로 고려해야할 사항이기 때문입니다.
- `Env` 구성시 `observation`을 직접 지정해 주어야 합니다. 기본적으로 현재 각 `BaseSystem`들의 상태를 모아서 리턴하면 됩니다. 이를 편리하게 하기 위해 기본적으로 `BaseEnv.observe_dict` 와 `BaseEnv.observe_flat` 메소드를 제공합니다.
- `BaseEnv.step` 메소드는 RL 환경 구성 시, reward 나 terminate 조건을 설정하는데 필요하기 때문에 사용자가 직접 구성하여야 하는데, 이전보다 훨씬 간단해졌습니다. 단순히 `BaseEnv.update(action)` 을 호출하는 것만으로도 `BaseSystem` 들의 state 와 `BaseEnv.clock` 이 업데이트 됩니다.
- `BaseEnv.derivs`가 훨씬 간단해졌습니다. 각 시스템들은 `BaseEnv.systems`에 리스트 형식으로 저장되어 있고, 미분값들은 `BaseSystem.set_dot` 메소드로 할당하기만 하면 됩니다. 이 방식의 장점은 굳이 `BaseSystem`을 상속받는 새로운 시스템 클래스를 만들고, 거기에 `deriv` 메소드를 구성할 필요가 없다는 점입니다. 다시말해 간단한 시스템을 짤 때는 `BaseEnv` 만으로 모든 것을 구성할 수 있습니다.