### PR TITLE
Add comment on PR #125

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -237,9 +237,6 @@ class BaseSystem:
     def dot(self, dot):
         self._dot = dot
 
-    def deriv(self):
-        raise NotImplementedError("deriv method is not defined in the system.")
-
     def reset(self):
         self.state = self.initial_state
         return self.state

--- a/fym/models/aircraft.py
+++ b/fym/models/aircraft.py
@@ -97,8 +97,8 @@ class F16LinearLateral(BaseSystem):
     def __init__(self, initial_state=[1, 0, 0, 0, 0, 0, 0]):
         super().__init__(initial_state)
 
-    def deriv(self, x, u):
-        return self.A.dot(x) + self.B.dot(u)
+    def set_dot(self, x, u):
+        self.dot = self.A.dot(x) + self.B.dot(u)
 
 
 class MorphingPlane(BaseEnv):


### PR DESCRIPTION
@seong-hun 

## Done
- `core.py` 에 `deriv` method 가 필요없어져서 삭제 (혹시 이전 버전에 있는 네이밍때문에 일부러 오류를 출력하려고 남기신건가요?)
- F16 선형모델에 `deriv` method -> `set_dot` method 로 변경

## Related issue or PR
- #125 