### PR TITLE
[plotting module] plot type 지정 기능 추가

### DIFF
--- a/fym/plotting.py
+++ b/fym/plotting.py
@@ -10,6 +10,21 @@ class Plotter:
     figures = OrderedDict()  # dictionary for figures
     tmp_name = 0
 
+    def __init__(self, plot_type="plot"):
+        self.plot_type = plot_type
+
+    def set_plot_type(self, plot_type):
+        self.plot_type = plot_type
+
+    def plot(self, ax, *args):
+        if self.plot_type == "plot":
+            result = ax.plot(*args)
+        elif self.plot_type == "step":
+            result = ax.step(*args)
+        else:
+            raise ValueError("{} is not a supported plot type.".format(self.plot_type))
+        return result
+
     def plot2d(self, x, y, name=None, xlabel='time (s)', ylabels=['x'], ncols=1):
         if not x.shape[0] == y.shape[0]:
             raise ValueError("The length of x must agree with those of y's.")
@@ -31,7 +46,8 @@ class Plotter:
                     break
                 else:
                     nplt += 1
-                    ax[i, j].plot(x, y[:, i])
+                    self.plot(ax[i, j], x, y[:, i])
+                    # ax[i, j].plot(x, y[:, i])
                     if len(ylabels) == 1:
                         if y.shape[1] == 1:
                             ax[i, j].set_ylabel(ylabels[0])

--- a/test/plot_figures.py
+++ b/test/plot_figures.py
@@ -21,5 +21,7 @@ plotter.plot2d(x, y)  # tmp
 plotter.plot2d(time, state)  # tmp
 plotter.plot2d(time, state, name='state', ncols=3)
 plotter.plot2d(time, ctrl, name='ctrl', xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'])
+plotter.set_plot_type("step")
+plotter.plot2d(time, ctrl, name='ctrl', xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'])
 
 plotter.show()


### PR DESCRIPTION
## Done
- `plotting.py` 에 그래프의 type 을 지정할 수 있는 기능을 추가하였습니다.
`plot_type` 은 기본값으로 `plot` 을 가지며, 현재 `plot`, `step` 두 속성을 가질 수 있습니다.
- `set_plot_type` 메쏘드를 이용하여 `step` 형태의 그래프를 그리도록 class instance 의 속성을 변경할 수 있습니다.

예: `test/plot_figures.py` 내의 코드 중 일부:
```python3
plotter.plot2d(time, ctrl, name='ctrl', xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'])
plotter.set_plot_type("step")
plotter.plot2d(time, ctrl, name='ctrl', xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'])
```

결과 비교:
- `plot_type = plot` 을 이용한 경우: ![image](https://user-images.githubusercontent.com/43136096/73429441-0b6fb800-437f-11ea-914d-81cc3612df96.png)
- `plot_type = step` 을 이용한 경우: ![image](https://user-images.githubusercontent.com/43136096/73429450-132f5c80-437f-11ea-96ec-97e500749b44.png)

