### PR TITLE
Improve fym

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -194,7 +194,7 @@ class BaseEnv(gym.Env):
 
     def render(self, mode="tqdm"):
         if mode == "tqdm":
-            if self.tqdm_bar is None:
+            if self.tqdm_bar is None or self.clock.get() == 0:
                 self.tqdm_bar = tqdm.tqdm(
                     total=self.clock.max_len,
                     desc="Time"

--- a/fym/core.py
+++ b/fym/core.py
@@ -130,7 +130,8 @@ class BaseEnv(gym.Env):
             y0=self.observe_flat(),
             t=t_span,
             args=(action,) + args,
-            tfirst=True
+            tfirst=True,
+            **self.odeint_option
         )
 
         # Update the systems' state
@@ -158,7 +159,7 @@ class BaseEnv(gym.Env):
             for system in self.systems:
                 system.state = y[system.flat_index].reshape(system.state_shape)
             self.set_dot(t, *args)
-            return np.hstack([system.dot for system in self.systems])
+            return self.dot
         return wrapper
 
     def set_dot(self, time, *args):

--- a/fym/core.py
+++ b/fym/core.py
@@ -54,18 +54,21 @@ class BaseEnv(gym.Env):
 
         self.delay = None
 
-    def __repr__(self, indent=0):
+    def __repr__(self, base=[]):
         name = self.name or self.__class__.__name__
+        base = base + [name]
         result = [
-            " " * indent + f"<{name}>",
-            " " * indent + f"- state: {self.state}"
+            f"<{' - '.join(base)}>",
+            "state:",
+            f"{self.state}"
         ]
         if hasattr(self, "dot"):
-            result.append(" " * indent + f"- dot: {self.dot}")
+            result.append("dot:"
+                          f"{self.dot}")
         result.append("")
 
         for system in self.systems:
-            v_str = system.__repr__(indent + 2)
+            v_str = system.__repr__(base=base)
             result.append(v_str)
         return "\n".join(result)
 
@@ -210,16 +213,27 @@ class BaseSystem:
         self.state_shape = self.initial_state.shape
         self.name = name
 
-    def __repr__(self, indent=0):
+    def __repr__(self, base=[]):
         name = self.name or self.__class__.__name__
+        base = base + [name]
         result = [
-            " " * indent + f"<{name}>",
-            " " * indent + f"state: {self.state}"
+            f"<{' - '.join(base)}>",
+            "state:",
+            f"{self.state}"
         ]
         if hasattr(self, "dot"):
-            result.append(" " * indent + f"dot: {self.dot}")
+            result.append("dot:"
+                          f"{self.dot}")
         result.append("")
         return "\n".join(result)
+
+    @property
+    def state(self):
+        return self._state
+
+    @state.setter
+    def state(self, state):
+        self._state = state
 
     @property
     def initial_state(self):

--- a/fym/logging.py
+++ b/fym/logging.py
@@ -4,11 +4,11 @@ import os
 from datetime import datetime
 
 
-def save(h5file, dic):
+def save(h5file, dic, mode="w"):
     if not isinstance(h5file, h5py.File):
         if not os.path.exists(os.path.dirname(h5file)):
             os.makedirs(os.path.dirname(h5file), exist_ok=True)
-        with h5py.File(h5file, 'w') as h5file:
+        with h5py.File(h5file, mode) as h5file:
             _rec_save(h5file, '/', dic)
     else:
         _rec_save(h5file, '/', dic)
@@ -64,7 +64,8 @@ def _rec_update(base_dict, input_dict):
 
 
 class Logger:
-    def __init__(self, log_dir=None, file_name='data.h5', max_len=1e2):
+    def __init__(self, log_dir=None, file_name='data.h5', max_len=1e2,
+                 mode="w"):
         if log_dir is None:
             log_dir = os.path.join(
                 'log',
@@ -75,7 +76,7 @@ class Logger:
         self.basename = file_name
         self.path = os.path.join(log_dir, file_name)
         self.max_len = max_len
-        self.h5file = h5py.File(self.path, 'w')
+        self.h5file = h5py.File(self.path, mode)
         self.clear()
 
     def clear(self):

--- a/test/group_test.py
+++ b/test/group_test.py
@@ -3,17 +3,31 @@ import numpy as np
 from fym.core import BaseEnv, BaseSystem
 
 
-env = BaseEnv(
-    {
-        "main": BaseEnv({
-            "main_1": BaseSystem([0, 0, 0]),
-            "main_2": BaseSystem([1, 1, 1]),
-        }),
-        "sub": BaseSystem([2, 2, 2]),
-    },
-    dt=0.01,
-    max_t=10
-)
+class Env(BaseEnv):
+    def __init__(self):
+        super().__init__(
+            {
+                "main": BaseEnv({
+                    "main_1": BaseSystem(np.zeros((3, 3))),
+                    "main_2": BaseSystem(np.ones(4)),
+                }),
+                "sub": BaseSystem([2, 2, 2]),
+            },
+            dt=0.01,
+            max_t=10
+        )
+
+    def step(self, action):
+        self.update(action)
+
+    def set_dot(self, time, action):
+        self.systems_dict["main"].systems_dict["main_1"].dot = 0.1 * np.ones((3, 3))
+        self.systems_dict["main"].systems_dict["main_2"].dot = np.zeros(4)
+        self.systems_dict["sub"].dot = -0.1 * np.ones(3)
+
+
+env = Env()
 env.reset()
-env.systems_dict["main"].state = np.array([-1, -1, -1, -2, -2, -2])
-env.systems_dict["main"].systems_dict["main_2"].state = np.array([0, 0, 0])
+env.systems_dict["main"].state = np.array(
+    [1, 1, 1, 0, 0, 0, -1, -1, -1, -2, -2, -2, -2])
+env.systems_dict["main"].systems_dict["main_2"].state = np.array([0, 0, 0, 10])


### PR DESCRIPTION
- `__repr__` 메소드를 좀 더 보기 쉽게 만들었습니다
- `render` 메소드를 사용시, `env` 가 `reset` 되며 `tqdm` 도 다시 시작하도록 바꿨습니다.
- `fym.logging` 모듈에 `h5py` 파일 포인터를 만들 때 `mode`를 지정할 수 있게 바꿨습니다. 이제 `mode=a` 옵션을 주면 파일을 새로 만들거나 기존 파일에 이어서 저장할 수 있습니다.
- `BaseEnv`에서 `odeint` 사용시 `odeint_option` 으로 적분 설정값을 넣어줄 수 있게 바꿨습니다.
- `test/group_test.py` 를 조금 수정했습니다.