### PR TITLE
Update tqdm_bar

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -201,12 +201,12 @@ class BaseEnv(gym.Env):
         if self.tqdm_bar is not None:
             self.tqdm_bar.close()
 
-    def render(self, mode="tqdm", desc=None, leave=True):
+    def render(self, mode="tqdm", desc=None, **kwargs):
         if mode == "tqdm":
             if self.tqdm_bar is None or self.clock.get() == 0:
                 self.tqdm_bar = tqdm.tqdm(
                     total=self.clock.max_len,
-                    leave=leave,
+                    **kwargs
                 )
 
             self.tqdm_bar.update(1)

--- a/fym/core.py
+++ b/fym/core.py
@@ -198,16 +198,20 @@ class BaseEnv(gym.Env):
     def close(self):
         if not self.logging_off:
             self.logger.close()
+        if self.tqdm_bar is not None:
+            self.tqdm_bar.close()
 
-    def render(self, mode="tqdm"):
+    def render(self, mode="tqdm", desc=None, leave=True):
         if mode == "tqdm":
             if self.tqdm_bar is None or self.clock.get() == 0:
                 self.tqdm_bar = tqdm.tqdm(
                     total=self.clock.max_len,
-                    desc="Time"
+                    leave=leave,
                 )
 
             self.tqdm_bar.update(1)
+            if desc:
+                self.tqdm_bar.set_description(desc)
 
     def set_delay(self, systems: list, T):
         self.delay = Delay(self.clock, systems, T)


### PR DESCRIPTION
- Add `desc` and `leave` keywords to the `BaseEnv.render` method.
- The `desc` keyword changes the prefix of the tqdm bar, at each call.
- The `leave=True` (default: `False`) flushes out the tqdm bar in
  `sys.stderr` (console output).