### PR TITLE
Improve logger

### DIFF
--- a/fym/logging.py
+++ b/fym/logging.py
@@ -1,4 +1,4 @@
-import json
+import pickle
 import h5py
 import numpy as np
 import os
@@ -46,7 +46,7 @@ def load(path, with_info=False):
     with h5py.File(path, 'r') as h5file:
         ans = _rec_load(h5file, '/')
         if with_info:
-            return ans, json.loads(h5file.attrs["info"])
+            return ans, pickle.loads(h5file.attrs["info"].tostring())
         else:
             return ans
 
@@ -116,8 +116,8 @@ class Logger:
 
     def close(self):
         self.flush()
-        ser = json.dumps(self.info)
-        self.h5file.attrs.update(info=ser)
+        ser = pickle.dumps(self.info)
+        self.h5file.attrs.update(info=np.void(ser))
         self.h5file.close()
 
     def set_info(self, **kwargs):

--- a/fym/logging.py
+++ b/fym/logging.py
@@ -64,17 +64,19 @@ def _rec_update(base_dict, input_dict):
 
 
 class Logger:
-    def __init__(self, log_dir=None, file_name='data.h5', max_len=1e2,
-                 mode="w"):
-        if log_dir is None:
-            log_dir = os.path.join(
-                'log',
-                datetime.today().strftime('%Y%m%d-%H%M%S')
-            )
+    def __init__(self, path=None, log_dir=None, file_name='data.h5',
+                 max_len=1e2, mode="w"):
+        if path is not None:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+        else:
+            if log_dir is None:
+                log_dir = os.path.join(
+                    'log', datetime.today().strftime('%Y%m%d-%H%M%S'))
+            os.makedirs(log_dir, exist_ok=True)
+            path = os.path.join(log_dir, file_name)
 
-        os.makedirs(log_dir, exist_ok=True)
+        self.path = path
         self.basename = file_name
-        self.path = os.path.join(log_dir, file_name)
         self.max_len = max_len
         self.h5file = h5py.File(self.path, mode)
         self.clear()

--- a/fym/logging.py
+++ b/fym/logging.py
@@ -65,7 +65,7 @@ def _rec_update(base_dict, input_dict, is_info=False):
     """Recursively update ``base_dict`` with ``input_dict``."""
     for key, val in input_dict.items():
         if isinstance(val, dict):
-            _rec_update(base_dict.setdefault(key, {}), val)
+            _rec_update(base_dict.setdefault(key, {}), val, is_info)
         else:
             if is_info:
                 base_dict.update({key: val})


### PR DESCRIPTION
logger 에 info 데이터를 추가하는 기능을 만들었습니다.
`logger.set_info` 메소드를 사용하며, 중복 호출될 경우 같은 이름의 데이터는 덮어씌워 집니다.

다음과 같이 사용 가능합니다.

```python
import fym.logging as logging

logger = logging.Logger(path="test.h5")
logger.record(time=0, state=[1, 2, 3], control=0)
logger.record(time=1, state=[2, 3, 4], control=0.1)
logger.record(time=2, state=[0, 0, 0], control=0.3)
logger.set_info(name={"first": "Name", "second": "SecondName"}, number=6)
logger.set_info(name={"first": "ChangedName"}, newnumber=10)
logger.close()
data, info = logging.load("test.h5", with_info=True)
print(data, info)
```