### PR TITLE
[plotting] 3d plot 추가 및 subplot 개선

### DIFF
--- a/fym/plotting.py
+++ b/fym/plotting.py
@@ -1,6 +1,7 @@
 import numpy as np
 import math
 import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
 from collections import OrderedDict
 
 import fym
@@ -10,44 +11,128 @@ class Plotter:
     figures = OrderedDict()  # dictionary for figures
     tmp_name = 0
 
-    def __init__(self, plot_type="plot"):
-        self.plot_type = plot_type
+    def __init__(self):
+        pass
 
-    def set_plot_type(self, plot_type):
-        self.plot_type = plot_type
-
-    def plot(self, ax, *args):
-        if self.plot_type == "plot":
+    def _plot_raw(self, ax, plot_type, *args):
+        if plot_type == "plot":
             result = ax.plot(*args)
-        elif self.plot_type == "step":
+        elif plot_type == "step":
             result = ax.step(*args)
         else:
-            raise ValueError("{} is not a supported plot type.".format(self.plot_type))
+            raise ValueError(
+                "{} is not a supported plot type.".format(plot_type)
+            )
         return result
 
-    def plot2d(self, x, y, name=None, xlabel='time (s)', ylabels=['x'], ncols=1):
-        if not x.shape[0] == y.shape[0]:
-            raise ValueError("The length of x must agree with those of y's.")
+    def set_cols_and_rows(self, num_figures, ncols, dim):
+        nrows = math.ceil(num_figures/ncols)
+        if dim == 2:
+            fig, ax = plt.subplots(nrows, ncols)
+            if nrows == 1:
+                ax = np.expand_dims(ax, axis=0)
+            if ncols == 1:
+                ax = np.expand_dims(ax, axis=1)
+        elif dim == 3:
+            raise ValueError("3d not supported.")
+        return fig, ax, nrows
+
+    def fit_shape(self, *args):
+        if len(args) == 2:
+            x, y = args
+        elif len(args) == 3:
+            x, y, z = args
+            # check z
+            if x.shape[0] != z.shape[0]:
+                raise ValueError(
+                    "The length of x must agree with those of z's."
+                )
+            if len(z.shape) == 1:
+                z = np.expand_dims(z, axis=1)
+
+        # check y
+        if x.shape[0] != y.shape[0]:
+            raise ValueError(
+                "The length of x must agree with those of y's."
+            )
         if len(y.shape) == 1:
             y = np.expand_dims(y, axis=1)
+        # result
+        if len(args) == 2:
+            result = [x, y]
+        if len(args) == 3:
+            result = [x, y, z]
+        return result
 
-        nrows = math.ceil(y.shape[1]/ncols)
-        fig, ax = plt.subplots(nrows, ncols)
-        if nrows == 1:
-            ax = np.expand_dims(ax, axis=0)
-        if ncols == 1:
-            ax = np.expand_dims(ax, axis=1)
+    def _plot3d(self, ncols, xlabel, ylabels, zlabels, plot_type, *args):
+        # shape check
+        x, y, z = self.fit_shape(*args)
 
-        # plot 2d figure
+        # set cols and rows
+        num_figures = y.shape[1] * z.shape[1]
+        nrows = math.ceil(num_figures/ncols)
+        fig = plt.figure()
+
+        # TODO: merge filling subplots of 2d and that of 3d
+        # plot 3d figures
         nplt = 0
-        for j in range(ncols):
-            for i in range(nrows):
-                if nplt == y.shape[1]:
+        for j in range(ncols):  # y
+            for i in range(nrows):  # z
+                if nplt == num_figures:
                     break
                 else:
                     nplt += 1
-                    self.plot(ax[i, j], x, y[:, i])
-                    # ax[i, j].plot(x, y[:, i])
+                    ax = fig.add_subplot(nrows, ncols, nplt, projection='3d')
+                    self._plot_raw(ax, plot_type, x, y[:, j], z[:, i])
+                    # auto ylabel
+                    if len(ylabels) == 1:
+                        if y.shape[1] == 1:
+                            ax.set_ylabel(ylabels[0])
+                        else:
+                            ax.set_ylabel(ylabels[0]+'{}'.format(nplt))
+                    elif len(ylabels) == y.shape[1]:
+                        ax.set_ylabel(ylabels[i])
+                    else:
+                        raise ValueError(
+                            "The number of labels must agree"
+                            + " with the number of y's."
+                        )
+                    # auto zlabel
+                    if len(zlabels) == 1:
+                        if z.shape[1] == 1:
+                            ax.set_zlabel(zlabels[0])
+                        else:
+                            ax.set_zlabel(zlabels[0]+'{}'.format(nplt))
+                    elif len(zlabels) == z.shape[1]:
+                        ax.set_zlabel(zlabels[i])
+                    else:
+                        raise ValueError(
+                            "The number of labels must agree"
+                            + " with the number of z's."
+                        )
+            ax.set_xlabel(xlabel)
+
+        return fig, ax
+
+    def _plot2d(self, ncols, xlabel, ylabels, plot_type, *args):
+        # shape check
+        x, y = self.fit_shape(*args)
+
+        # set cols and rows
+        num_figures = y.shape[1]
+        fig, ax, nrows = self.set_cols_and_rows(
+            num_figures, ncols, len(args)
+        )
+
+        # plot 2d figures
+        nplt = 0
+        for j in range(ncols):
+            for i in range(nrows):
+                if nplt == num_figures:
+                    break
+                else:
+                    nplt += 1
+                    self._plot_raw(ax[i, j], plot_type, x, y[:, i])
                     if len(ylabels) == 1:
                         if y.shape[1] == 1:
                             ax[i, j].set_ylabel(ylabels[0])
@@ -56,10 +141,40 @@ class Plotter:
                     elif len(ylabels) == y.shape[1]:
                         ax[i, j].set_ylabel(ylabels[i])
                     else:
-                        raise ValueError("The number of labels must agree with the number of y's.")
+                        raise ValueError(
+                            "The number of labels must agree"
+                            + " with the number of y's."
+                        )
             ax[-1][j].set_xlabel(xlabel)
+        return fig, ax
+
+    def plot(
+        self, *args, name=None, ncols=1,
+        xlabel="x", ylabels=["y"], zlabels=["z"], plot_type="plot",
+    ):
+
+        # plot 2d figure
+        if len(args) == 2:
+            # plot
+            fig, ax = self._plot2d(
+                ncols, xlabel, ylabels, plot_type,
+                *args)
+        elif len(args) == 3:
+            # ignore plot_type
+            if plot_type != "plot":
+                plot_type = "plot"
+                print("plot_type = {plot_type} is ignored for 3d plot.")
+            # plot
+            fig, ax = self._plot3d(
+                ncols, xlabel, ylabels, zlabels, plot_type,
+                *args)
+        else:
+            raise ValueError("Invalid dimension for plotting.")
 
         # add an element into figures dictionary
+        self.add_dict(fig, ax, name)
+
+    def add_dict(self, fig, ax, name):
         if name is None:
             self.tmp_name += 1
             name = 'tmp{}'.format(self.tmp_name)
@@ -74,15 +189,5 @@ class Plotter:
 
 
 if __name__ == '__main__':
-    import fym.logging
-    data = fym.logging.load('data/main/result.h5')  # result obtained from fym.logging
-
-# data consists of three keys: state, action, time
-    state = data['state']
-# e.g., system name is "main".
-# Note: state consists of keys corresponding to each systems.
-    ctrl = data['control']
-    time = data['time']
-
-    plotter = Plotter()
-    plotter.plot2d(time, state)  # tmp
+    pass
+    # for more detail, see "../test/plot_figures.py"

--- a/fym/plotting.py
+++ b/fym/plotting.py
@@ -25,18 +25,6 @@ class Plotter:
             )
         return result
 
-    def set_cols_and_rows(self, num_figures, ncols, dim):
-        nrows = math.ceil(num_figures/ncols)
-        if dim == 2:
-            fig, ax = plt.subplots(nrows, ncols)
-            if nrows == 1:
-                ax = np.expand_dims(ax, axis=0)
-            if ncols == 1:
-                ax = np.expand_dims(ax, axis=1)
-        elif dim == 3:
-            raise ValueError("3d not supported.")
-        return fig, ax, nrows
-
     def fit_shape(self, *args):
         if len(args) == 2:
             x, y = args
@@ -63,6 +51,40 @@ class Plotter:
         if len(args) == 3:
             result = [x, y, z]
         return result
+
+    def _plot2d(self, ncols, xlabel, ylabels, plot_type, *args):
+        # shape check
+        x, y = self.fit_shape(*args)
+
+        # set cols and rows
+        num_figures = y.shape[1]
+        nrows = math.ceil(num_figures/ncols)
+        fig = plt.figure()
+
+        # plot 2d figures
+        nplt = 0
+        for j in range(ncols):
+            for i in range(nrows):
+                if nplt == num_figures:
+                    break
+                else:
+                    nplt += 1
+                    ax = fig.add_subplot(nrows, ncols, nplt)
+                    self._plot_raw(ax, plot_type, x, y[:, i])
+                    if len(ylabels) == 1:
+                        if y.shape[1] == 1:
+                            ax.set_ylabel(ylabels[0])
+                        else:
+                            ax.set_ylabel(ylabels[0]+'{}'.format(nplt))
+                    elif len(ylabels) == y.shape[1]:
+                        ax.set_ylabel(ylabels[i])
+                    else:
+                        raise ValueError(
+                            "The number of labels must agree"
+                            + " with the number of y's."
+                        )
+            ax.set_xlabel(xlabel)
+        return fig, ax
 
     def _plot3d(self, ncols, xlabel, ylabels, zlabels, plot_type, *args):
         # shape check
@@ -112,40 +134,6 @@ class Plotter:
                         )
             ax.set_xlabel(xlabel)
 
-        return fig, ax
-
-    def _plot2d(self, ncols, xlabel, ylabels, plot_type, *args):
-        # shape check
-        x, y = self.fit_shape(*args)
-
-        # set cols and rows
-        num_figures = y.shape[1]
-        fig, ax, nrows = self.set_cols_and_rows(
-            num_figures, ncols, len(args)
-        )
-
-        # plot 2d figures
-        nplt = 0
-        for j in range(ncols):
-            for i in range(nrows):
-                if nplt == num_figures:
-                    break
-                else:
-                    nplt += 1
-                    self._plot_raw(ax[i, j], plot_type, x, y[:, i])
-                    if len(ylabels) == 1:
-                        if y.shape[1] == 1:
-                            ax[i, j].set_ylabel(ylabels[0])
-                        else:
-                            ax[i, j].set_ylabel(ylabels[0]+'{}'.format(nplt))
-                    elif len(ylabels) == y.shape[1]:
-                        ax[i, j].set_ylabel(ylabels[i])
-                    else:
-                        raise ValueError(
-                            "The number of labels must agree"
-                            + " with the number of y's."
-                        )
-            ax[-1][j].set_xlabel(xlabel)
         return fig, ax
 
     def plot(

--- a/test/plot_figures.py
+++ b/test/plot_figures.py
@@ -1,27 +1,44 @@
 import numpy as np
 
-import fym
+import fym.logging as logging
 import fym.plotting as plotting
-import fym.logging
 
 
-data = fym.logging.load('data/plot_figures/result.h5')  # a simulation result obtained from fym
+# compatibility check for fym.logging
+data = logging.load('data/plot_figures/result.h5')  # tmp
 
-# data consists of three keys: state, action, time
 state = data['state']
-# e.g., system name is "main".
-# Note: state consists of keys corresponding to each systems.
-ctrl = data['control']
+control = data['control']
 time = data['time']
 
+# auxiliary
+x = np.linspace(0., 100., num=100)
+y = x.reshape(-1, 1)
+z = np.random.rand(100, 2)
+
+# Plotter
 plotter = plotting.Plotter()
-x = np.linspace(0.0, 1.0, num=100)
-y = x
-plotter.plot2d(x, y)  # tmp
-plotter.plot2d(time, state)  # tmp
-plotter.plot2d(time, state, name='state', ncols=3)
-plotter.plot2d(time, ctrl, name='ctrl', xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'])
-plotter.set_plot_type("step")
-plotter.plot2d(time, ctrl, name='ctrl', xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'])
+# plot (2d)
+plotter.plot(x, y)  # tmp
+plotter.plot(
+    time, state,
+    name="state", ncols=3
+)
+plotter.plot(
+    time, control,
+    name="control",
+    xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'],
+)
+
+# step
+plotter.plot(
+    time, control,
+    name="control (step)",
+    xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'],
+    plot_type="step",
+)
+
+# plot (3d)
+plotter.plot(x, y, z)
 
 plotter.show()


### PR DESCRIPTION
기존의 `plotting.py` 을 개선하였습니다.

## Done
- 3d plot 기능을 추가함 (subplot 가능)
- 기존 subplot 을 그릴 때 불필요한 빈 칸이 그려지는 현상을 제거하여 개선
- 2d, 3d 모두 하나의 명령어로 그래프를 그릴 수 있음

## Note
- 사전에 `plot_type` 을 지정하는 방식에서, plot 시 지정하는 방식으로 변경됨
- 예시 코드:
```python3
import numpy as np

import fym.logging as logging
import fym.plotting as plotting


# compatibility check for fym.logging
data = logging.load('data/plot_figures/result.h5')  # tmp

state = data['state']
control = data['control']
time = data['time']

# auxiliary
x = np.linspace(0., 100., num=100)
y = x.reshape(-1, 1)
z = np.random.rand(100, 2)

# Plotter
plotter = plotting.Plotter()
# plot (2d)
plotter.plot(x, y)  # tmp
plotter.plot(
    time, state,
    name="state", ncols=3
)
plotter.plot(
    time, control,
    name="control",
    xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'],
)

# step
plotter.plot(
    time, control,
    name="control (step)",
    xlabel='t (s)', ylabels=['$L (g)$', '$\phi (deg)$'],
    plot_type="step",
)

# plot (3d)
plotter.plot(x, y, z)

plotter.show()
```
- 다음은 `test/plot_figures.py` 를 실행한 그래프 출력 결과 예시임:
- 3차원 subplots
![image](https://user-images.githubusercontent.com/43136096/75089962-6b820480-55a1-11ea-8489-b4b0f046dd7f.png)
- 2차원 subplots (기존과 동일)
![image](https://user-images.githubusercontent.com/43136096/75089969-85bbe280-55a1-11ea-8f03-92d5177593e8.png)

- 2차원 subplots, step 버전 (기존과 동일)
![image](https://user-images.githubusercontent.com/43136096/75089968-7f2d6b00-55a1-11ea-932a-85a488a49bef.png)

## Related branch
- `add-3d-plot`