### PR TITLE
Fix #139

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -427,7 +427,7 @@ def deep_flatten(arg):
 
 
 def infinite_box(shape):
-    return gym.spaces.Box(-np.inf, np.inf, shape=shape, dtype=np.float32)
+    return gym.spaces.Box(-np.inf, np.inf, shape=shape, dtype=np.float64)
 
 
 def infer_obs_space(obj):


### PR DESCRIPTION
- `gym` 1.17 버전에서는 warning 이 발생하고, 1.15 버전에서는 발생하지 않음
- warning 내용은 #139 참고
- dtype 을 float 32 -> float 64 로 변경하여 문제를 해결함 (해당 방법을 적용했을 때 `gym` 1.15 버전에서도 유효함을 확인)