### PR TITLE
BaseSystem improve

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -212,7 +212,7 @@ class BaseEnv(gym.Env):
         if self.delay:
             self.delay.update(t_hist, ode_hist)
 
-        return t_hist, ode_hist, done
+        return t_hist, ode_hist, done or self.clock.time_over()
 
     def ode_wrapper(self, func):
         @functools.wraps(func)

--- a/fym/core.py
+++ b/fym/core.py
@@ -275,7 +275,9 @@ class BaseEnv(gym.Env):
 
 
 class BaseSystem:
-    def __init__(self, initial_state, name=None):
+    def __init__(self, initial_state=None, shape=(1, 1), name=None):
+        if initial_state is None:
+            initial_state = np.zeros(shape)
         self.initial_state = initial_state
         self.state = self.initial_state
         self.state_shape = self.initial_state.shape


### PR DESCRIPTION
`BaseSystem`을 조금 더 간단하게 선언할 수 있도록 바꿨습니다.

예시:
```python
a = BaseSystem()  # 초기 상태: zeros(1, 1) 
a = BaseSystem(shape=(2, 3))  # 초기 상태: zeros(2, 3)
a = BaseSystem([1, 2])  # 이전과 같음
```