### PR TITLE
Add new plot type (scatter) and label, lim of figures

### DIFF
--- a/fym/plotting.py
+++ b/fym/plotting.py
@@ -114,9 +114,19 @@ def _plot3d(figs, fig_name, fig_dict, data_dict, weight_dict):
             ax.scatter(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)
         else:
             ax.plot(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)  # default
-        ax.set_xlabel(fig_dict["xlabel"])
-        ax.set_ylabel(fig_dict["ylabel"])
-        ax.set_zlabel(fig_dict["zlabel"])
+        # label, lim
+        if fig_dict.get("xlabel") is not None:
+            ax.set_xlabel(fig_dict["xlabel"])
+        if fig_dict.get("ylabel") is not None:
+            ax.set_ylabel(fig_dict["ylabel"])
+        if fig_dict.get("zlabel") is not None:
+            ax.set_zlabel(fig_dict["zlabel"])
+        if fig_dict.get("xlim") is not None:
+            ax.set_xlim3d(*fig_dict["xlim"])
+        if fig_dict.get("ylim") is not None:
+            ax.set_ylim3d(*fig_dict["ylim"])
+        if fig_dict.get("zlim") is not None:
+            ax.set_zlim3d(*fig_dict["zlim"])
         ax.set_title(fig_name)
     if fig_dict.get("label") is not None:
         ax.legend()
@@ -155,10 +165,15 @@ def _plot2d(figs, fig_name, fig_dict, data_dict, weight_dict):
                 ax[i].scatter(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)
             else:
                 ax[i].plot(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)  # default
-            ax[i].set_xlabel(fig_dict["xlabel"])
-            ax[i].set_ylabel(fig_dict["ylabel"][i])
-            if "ylim" in fig_dict:
-                ax[i].set_ylim(fig_dict["ylim"][i])
+            # label, lim
+            if fig_dict.get("xlabel") is not None:
+                ax[i].set_xlabel(fig_dict["xlabel"])
+            if fig_dict.get("ylabel") is not None:
+                ax[i].set_ylabel(fig_dict["ylabel"][i])
+            if fig_dict.get("xlim") is not None:
+                ax[i].set_xlim(*fig_dict["xlim"])
+            if fig_dict.get("ylim") is not None:
+                ax[i].set_ylim(*fig_dict["ylim"][i])
     ax[0].set_title(fig_name)
     if fig_dict.get("label") is not None:
         ax[0].legend()

--- a/fym/plotting.py
+++ b/fym/plotting.py
@@ -80,9 +80,9 @@ def plot(data_dict, draw_dict, weight_dict={}, save_dir="./",
     for fig_name in draw_dict:
         figs[fig_name] = plt.figure()
         fig_dict = draw_dict[fig_name]
-        if fig_dict["type"] == "3d":
+        if fig_dict["projection"] == "3d":
             _plot3d(figs, fig_name, fig_dict, data_dict, weight_dict)
-        elif fig_dict["type"] == "2d":
+        elif fig_dict["projection"] == "2d":
             _plot2d(figs, fig_name, fig_dict, data_dict, weight_dict)
         os.makedirs(save_dir, exist_ok=True)
         fig_path = os.path.join(save_dir, fig_name)
@@ -95,7 +95,7 @@ def _plot3d(figs, fig_name, fig_dict, data_dict, weight_dict):
     # 3d graph
     ax = figs[fig_name].add_subplot(1, 1, 1, projection="3d")
     for i_plt, plot_name in enumerate(fig_dict["plot"]):
-        x, y, z = [data_dict[plot_name][:, i] for i in range(3)]
+        data_x, data_y, data_z = [data_dict[plot_name][:, i] for i in range(3)]
         # ax.set_aspect("equal")  # not supported
         # weight
         weights_xyz = weight_dict.get(plot_name)
@@ -107,7 +107,13 @@ def _plot3d(figs, fig_name, fig_dict, data_dict, weight_dict):
         plot_property_dict = {}
         for key in ["c", "label", "alpha"]:
             plot_property_dict[key] = _get_plot_property(fig_dict, key, i_plt)
-        ax.plot(w_x*x, w_y*y, w_z*z, **plot_property_dict)
+        plot_type = fig_dict.get("type")
+        if plot_type is None:
+            ax.plot(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)  # default
+        elif plot_type[i_plt] == "scatter":
+            ax.scatter(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)
+        else:
+            ax.plot(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)  # default
         ax.set_xlabel(fig_dict["xlabel"])
         ax.set_ylabel(fig_dict["ylabel"])
         ax.set_zlabel(fig_dict["zlabel"])
@@ -142,7 +148,13 @@ def _plot2d(figs, fig_name, fig_dict, data_dict, weight_dict):
             plot_property_dict = {}
             for key in ["c", "label", "alpha"]:
                 plot_property_dict[key] = _get_plot_property(fig_dict, key, i_plt)
-            ax[i].plot(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)
+            plot_type = fig_dict.get("type")
+            if plot_type is None:
+                ax[i].plot(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)  # default
+            elif plot_type[i_plt] == "scatter":
+                ax[i].scatter(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)
+            else:
+                ax[i].plot(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)  # default
             ax[i].set_xlabel(fig_dict["xlabel"])
             ax[i].set_ylabel(fig_dict["ylabel"][i])
             if "ylim" in fig_dict:

--- a/test/plot_figures.py
+++ b/test/plot_figures.py
@@ -30,8 +30,9 @@ draw_dict = {
         "projection": "3d",
         "type": ["plot", "scatter"],
         "xlabel": "x0 (m)",
-        "ylabel": "x1 (m)",
+        # "ylabel": "x1 (m)",
         "zlabel": "x2 (m)",
+        "xlim": [0., 1.],
         "c": ["b"],
         "label": ["3d_example"]
     },
@@ -40,6 +41,7 @@ draw_dict = {
         "projection": "2d",
         "xlabel": "t (s)",
         "ylabel": ["u0 (deg)", "u1 (deg)"],
+        "ylim": [[-3e3, 4e3], [1e3, 9e3]],
         "c": ["r", "b"],
         "label": ["u_shift", "u"],
         "alpha": [0.5, 0.1],

--- a/test/plot_figures.py
+++ b/test/plot_figures.py
@@ -26,8 +26,9 @@ data_dict["control_shift"] = data["control"] + np.rad2deg(1)  # broadcasting; fo
 # make draw dictionaries
 draw_dict = {
     "state_012": {
-        "plot": ["state3d"],
-        "type": "3d",
+        "plot": ["state3d", "state3d"],
+        "projection": "3d",
+        "type": ["plot", "scatter"],
         "xlabel": "x0 (m)",
         "ylabel": "x1 (m)",
         "zlabel": "x2 (m)",
@@ -36,7 +37,7 @@ draw_dict = {
     },
     "control": {
         "plot": [["time", "control_shift"], ["time", "control"]],
-        "type": "2d",
+        "projection": "2d",
         "xlabel": "t (s)",
         "ylabel": ["u0 (deg)", "u1 (deg)"],
         "c": ["r", "b"],


### PR DESCRIPTION
## Done
- 새로운 plot type 추가 (`scatter`)
    - 그래프 타입을 `type` 로 지정 가능
    - 예시: `./test` 에서`plot_figures.py` 를 실행
        - #147 참고
- label, lim 추가
### 예시
새로 변경된 부분: `scatter` 형식의 그래프 작성 가능, lim 추가 등
- 관련 코드 중... :
```python3
draw_dict = {
    "state_012": {
        "plot": ["state3d", "state3d"],
        "projection": "3d",
        "type": ["plot", "scatter"],
        "xlabel": "x0 (m)",
        # "ylabel": "x1 (m)",
        "zlabel": "x2 (m)",
        "xlim": [0., 1.],
        "c": ["b"],
        "label": ["3d_example"]
    },
    "control": {
        "plot": [["time", "control_shift"], ["time", "control"]],
        "projection": "2d",
        "xlabel": "t (s)",
        "ylabel": ["u0 (deg)", "u1 (deg)"],
        "ylim": [[-3e3, 4e3], [1e3, 9e3]],
        "c": ["r", "b"],
        "label": ["u_shift", "u"],
        "alpha": [0.5, 0.1],
    },
}
```
결과:
![control](https://user-images.githubusercontent.com/43136096/90589451-17d33980-e219-11ea-8906-4fb98ee3f8d2.png)
![state_012](https://user-images.githubusercontent.com/43136096/90589454-1a359380-e219-11ea-9c1c-84ffd6ad4148.png)




## Note
- 그래프 차원을 결정하는 변수명을 `type` -> `projection` 으로 변경
- 일일히 그래프 타입을 추가하지 않고, `method` 명을 직접 넣는 방법을 아시는 분은 코멘트 부탁드립니다 ㅠ