### PR TITLE
Add axis equal for 3d plot

### DIFF
--- a/fym/plotting.py
+++ b/fym/plotting.py
@@ -114,9 +114,19 @@ def _plot3d(figs, fig_name, fig_dict, data_dict, weight_dict):
             ax.scatter(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)
         else:
             ax.plot(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)  # default
-        ax.set_xlabel(fig_dict["xlabel"])
-        ax.set_ylabel(fig_dict["ylabel"])
-        ax.set_zlabel(fig_dict["zlabel"])
+        # label, lim
+        if fig_dict.get("xlabel") is not None:
+            ax.set_xlabel(fig_dict["xlabel"])
+        if fig_dict.get("ylabel") is not None:
+            ax.set_ylabel(fig_dict["ylabel"])
+        if fig_dict.get("zlabel") is not None:
+            ax.set_zlabel(fig_dict["zlabel"])
+        if fig_dict.get("xlim") is not None:
+            ax.set_xlim3d(*fig_dict["xlim"])
+        if fig_dict.get("ylim") is not None:
+            ax.set_ylim3d(*fig_dict["ylim"])
+        if fig_dict.get("zlim") is not None:
+            ax.set_zlim3d(*fig_dict["zlim"])
         ax.set_title(fig_name)
     if fig_dict.get("label") is not None:
         ax.legend()
@@ -155,10 +165,15 @@ def _plot2d(figs, fig_name, fig_dict, data_dict, weight_dict):
                 ax[i].scatter(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)
             else:
                 ax[i].plot(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)  # default
-            ax[i].set_xlabel(fig_dict["xlabel"])
-            ax[i].set_ylabel(fig_dict["ylabel"][i])
-            if "ylim" in fig_dict:
-                ax[i].set_ylim(fig_dict["ylim"][i])
+            # label, lim
+            if fig_dict.get("xlabel") is not None:
+                ax[i].set_xlabel(fig_dict["xlabel"])
+            if fig_dict.get("ylabel") is not None:
+                ax[i].set_ylabel(fig_dict["ylabel"][i])
+            if fig_dict.get("xlim") is not None:
+                ax[i].set_xlim(*fig_dict["xlim"])
+            if fig_dict.get("ylim") is not None:
+                ax[i].set_ylim(*fig_dict["ylim"][i])
     ax[0].set_title(fig_name)
     if fig_dict.get("label") is not None:
         ax[0].legend()

--- a/fym/plotting.py
+++ b/fym/plotting.py
@@ -80,9 +80,9 @@ def plot(data_dict, draw_dict, weight_dict={}, save_dir="./",
     for fig_name in draw_dict:
         figs[fig_name] = plt.figure()
         fig_dict = draw_dict[fig_name]
-        if fig_dict["type"] == "3d":
+        if fig_dict["projection"] == "3d":
             _plot3d(figs, fig_name, fig_dict, data_dict, weight_dict)
-        elif fig_dict["type"] == "2d":
+        elif fig_dict["projection"] == "2d":
             _plot2d(figs, fig_name, fig_dict, data_dict, weight_dict)
         os.makedirs(save_dir, exist_ok=True)
         fig_path = os.path.join(save_dir, fig_name)
@@ -95,7 +95,7 @@ def _plot3d(figs, fig_name, fig_dict, data_dict, weight_dict):
     # 3d graph
     ax = figs[fig_name].add_subplot(1, 1, 1, projection="3d")
     for i_plt, plot_name in enumerate(fig_dict["plot"]):
-        x, y, z = [data_dict[plot_name][:, i] for i in range(3)]
+        data_x, data_y, data_z = [data_dict[plot_name][:, i] for i in range(3)]
         # ax.set_aspect("equal")  # not supported
         # weight
         weights_xyz = weight_dict.get(plot_name)
@@ -107,7 +107,13 @@ def _plot3d(figs, fig_name, fig_dict, data_dict, weight_dict):
         plot_property_dict = {}
         for key in ["c", "label", "alpha"]:
             plot_property_dict[key] = _get_plot_property(fig_dict, key, i_plt)
-        ax.plot(w_x*x, w_y*y, w_z*z, **plot_property_dict)
+        plot_type = fig_dict.get("type")
+        if plot_type is None:
+            ax.plot(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)  # default
+        elif plot_type[i_plt] == "scatter":
+            ax.scatter(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)
+        else:
+            ax.plot(w_x*data_x, w_y*data_y, w_z*data_z, **plot_property_dict)  # default
         ax.set_xlabel(fig_dict["xlabel"])
         ax.set_ylabel(fig_dict["ylabel"])
         ax.set_zlabel(fig_dict["zlabel"])
@@ -142,7 +148,13 @@ def _plot2d(figs, fig_name, fig_dict, data_dict, weight_dict):
             plot_property_dict = {}
             for key in ["c", "label", "alpha"]:
                 plot_property_dict[key] = _get_plot_property(fig_dict, key, i_plt)
-            ax[i].plot(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)
+            plot_type = fig_dict.get("type")
+            if plot_type is None:
+                ax[i].plot(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)  # default
+            elif plot_type[i_plt] == "scatter":
+                ax[i].scatter(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)
+            else:
+                ax[i].plot(w_x*data_x, w_y*data_y[:, i], **plot_property_dict)  # default
             ax[i].set_xlabel(fig_dict["xlabel"])
             ax[i].set_ylabel(fig_dict["ylabel"][i])
             if "ylim" in fig_dict:

--- a/test/plot_figures.py
+++ b/test/plot_figures.py
@@ -9,35 +9,38 @@ import fym.logging
 
 data = fym.logging.load('data/plot_figures/result.h5')  # a simulation result obtained from fym
 
-# - class 'Plotter' (will be deprecated)
-# data consists of three keys: state, action, time
-state = data['state']
-# e.g., system name is "main".
-# Note: state consists of keys corresponding to each systems.
-ctrl = data['control']
-time = data['time']
-plotter = plotting.Plotter()
-plotter.plot2d(time, state)  # tmp
-
 # - function 'plot' (compatible with Matplotlib.pyplot)
 data_dict = data
 data_dict["state3d"] = data["state"][:, :3]  # for 3d example
 data_dict["control_shift"] = data["control"] + np.rad2deg(1)  # broadcasting; for 2d example
 # make draw dictionaries
 draw_dict = {
-    "state_012": {
-        "plot": ["state3d", "state3d"],
+    "state_012_equal": {
+        "plot": ["state3d"],
         "projection": "3d",
-        "type": ["plot", "scatter"],
+        "type": ["plot"],
         "xlabel": "x0 (m)",
         # "ylabel": "x1 (m)",
         "zlabel": "x2 (m)",
-        "xlim": [0., 1.],
+        # "xlim": [0., 1.],
         "c": ["b"],
-        "label": ["3d_example"]
+        "label": ["3d_example"],
+        "axis": "equal",
+    },
+    "state_012": {
+        "plot": ["state3d"],
+        "projection": "3d",
+        "type": ["plot"],
+        "xlabel": "x0 (m)",
+        # "ylabel": "x1 (m)",
+        "zlabel": "x2 (m)",
+        # "xlim": [0., 1.],
+        "c": ["b"],
+        "label": ["3d_example"],
     },
     "control": {
         "plot": [["time", "control_shift"], ["time", "control"]],
+        "type": ["plot", "scatter"],
         "projection": "2d",
         "xlabel": "t (s)",
         "ylabel": ["u0 (deg)", "u1 (deg)"],
@@ -45,6 +48,7 @@ draw_dict = {
         "c": ["r", "b"],
         "label": ["u_shift", "u"],
         "alpha": [0.5, 0.1],
+        # "axis": "equal",
     },
 }
 weight_dict = {

--- a/test/plot_figures.py
+++ b/test/plot_figures.py
@@ -30,8 +30,9 @@ draw_dict = {
         "projection": "3d",
         "type": ["plot", "scatter"],
         "xlabel": "x0 (m)",
-        "ylabel": "x1 (m)",
+        # "ylabel": "x1 (m)",
         "zlabel": "x2 (m)",
+        "xlim": [0., 1.],
         "c": ["b"],
         "label": ["3d_example"]
     },
@@ -40,6 +41,7 @@ draw_dict = {
         "projection": "2d",
         "xlabel": "t (s)",
         "ylabel": ["u0 (deg)", "u1 (deg)"],
+        "ylim": [[-3e3, 4e3], [1e3, 9e3]],
         "c": ["r", "b"],
         "label": ["u_shift", "u"],
         "alpha": [0.5, 0.1],

--- a/test/plot_figures.py
+++ b/test/plot_figures.py
@@ -26,8 +26,9 @@ data_dict["control_shift"] = data["control"] + np.rad2deg(1)  # broadcasting; fo
 # make draw dictionaries
 draw_dict = {
     "state_012": {
-        "plot": ["state3d"],
-        "type": "3d",
+        "plot": ["state3d", "state3d"],
+        "projection": "3d",
+        "type": ["plot", "scatter"],
         "xlabel": "x0 (m)",
         "ylabel": "x1 (m)",
         "zlabel": "x2 (m)",
@@ -36,7 +37,7 @@ draw_dict = {
     },
     "control": {
         "plot": [["time", "control_shift"], ["time", "control"]],
-        "type": "2d",
+        "projection": "2d",
         "xlabel": "t (s)",
         "ylabel": ["u0 (deg)", "u1 (deg)"],
         "c": ["r", "b"],


### PR DESCRIPTION
## Done
- 3차원 그래프의 axis equal 기능 추가
- `test/plot_figures.py` 실행 시 결과 비교
1. axis equal 적용 안함
![state_012](https://user-images.githubusercontent.com/43136096/91113781-5194bc00-e6c1-11ea-8b6e-2221d33c3104.png)

2. 적용 시
![state_012_equal](https://user-images.githubusercontent.com/43136096/91113786-535e7f80-e6c1-11ea-8c5d-0df106a09903.png)

## Note
- `pyplot` 에서 기본적으로 3차원 그래프의 axis equal 기능을 지원하지 않음... 2차원 그래프의 경우 `ax.axis("equal")` 로 가능하나, 3차원은 아래와 같은 오류 메시지가 나타남:
![image](https://user-images.githubusercontent.com/43136096/91113635-05e21280-e6c1-11ea-9363-4e4fc9e9d90c.png)
- 해결 방법은 [Stack Overflow 답변](https://stackoverflow.com/questions/13685386/matplotlib-equal-unit-length-with-equal-aspect-ratio-z-axis-is-not-equal-to) 을 참고함