### PR TITLE
Add a parser module

### DIFF
--- a/fym/utils/parser.py
+++ b/fym/utils/parser.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace as SN
+from functools import reduce
+import re
+
+
+def make_clean(string):
+    """From https://stackoverflow.com/a/3305731"""
+    return re.sub(r"\W+|^(?=\d)", "_", string)
+
+
+class SimpleSN(SN):
+    def __repr__(self, indent=0):
+        items = ["{"]
+        indent += 1
+        for key, val in self.__dict__.items():
+            item = "  " * indent + str(key) + ": "
+            if isinstance(val, SN):
+                item += val.__repr__(indent)
+            else:
+                item += str(val)
+            item += ","
+            items.append(item)
+        indent -= 1
+        items.append("  " * indent + "}")
+        return "\n".join(items)
+
+
+def nested_merge(a, b):
+    for k, v in b.items():
+        if k in a and isinstance(v, dict) and isinstance(a[k], dict):
+            nested_merge(a[k], b[k])
+        else:
+            a[k] = b[k]
+
+
+def dotdict2nestdict(data):
+    out = {}
+    for keystring, val in data.items():
+        if isinstance(val, dict):
+            val = dotdict2nestdict(val)
+        d = reduce(lambda d, k: {k: d}, keystring.split(".")[::-1], val)
+        nested_merge(out, d)
+    return out
+
+
+def nestdict2sn(d):
+    out = SimpleSN()
+    for k, v in d.items():
+        if isinstance(v, dict):
+            setattr(out, make_clean(k), nestdict2sn(v))
+        else:
+            setattr(out, make_clean(k), v)
+    return out
+
+
+def parse(json_dict):
+    return nestdict2sn(dotdict2nestdict(json_dict))
+
+
+if __name__ == "__main__":
+    import json
+
+    settings = {
+        "diffEditor.codeLens": False,
+        "diffEditor.ignoreTrimWhitespace": True,
+        "diffEditor.maxComputationTime": 5000,
+        "diffEditor.renderIndicators": True,
+        "diffEditor.renderSideBySide": True,
+        "diffEditor.wordWrap": "inherit",
+        "editor.acceptSuggestionOnCommitCharacter": True,
+        "editor.acceptSuggestionOnEnter": "on",
+        "editor.rulers": [],
+        "editor.scrollBeyondLastColumn": 5,
+        "editor.scrollBeyondLastLine": True,
+        "workbench.colorCustomizations": {
+            "editor.background": "#000088",
+            "editor.selectionBackground": "#008800",
+            "Custom setup": 1,
+            "3": 3,
+        }
+    }
+    f = json.dumps(settings)
+    config_json = json.loads(f)
+    parsing_from_json = parse(config_json)
+    parsing_from_dict = parse(settings)

--- a/fym/utils/parser.py
+++ b/fym/utils/parser.py
@@ -110,7 +110,7 @@ def update(sn, d):
         if k in sn and isinstance(v, (dict, SN)) and isinstance(sn[k], (dict, SN)):
             update(sn[k], d[k])
         else:
-            sn[k] = d[k]
+            sn[k] = encode(d[k])
 
 
 if __name__ == "__main__":
@@ -125,7 +125,6 @@ if __name__ == "__main__":
             "env.kwargs.dt": 0.01,
             "env.kwargs.max_t": 10,
             "env.solver": "rk4",
-            "etc": SN(k1=1, k2=dict(k21=2, k22=SN(k221=3, k222=dict(k2221=4)))),
         })
 
         parser.update(agents_cfg, {
@@ -134,3 +133,5 @@ if __name__ == "__main__":
         })
 
     load_config()
+
+    cfg.env.kwargs.dt = 0.02

--- a/fym/utils/parser.py
+++ b/fym/utils/parser.py
@@ -1,3 +1,4 @@
+import numpy as np
 from types import SimpleNamespace as SN
 from functools import reduce
 import re
@@ -11,6 +12,10 @@ class PrettySN(SN):
             item = "  " * indent + str(key) + ": "
             if isinstance(val, SN):
                 item += val.__repr__(indent)
+            elif isinstance(val, np.ndarray):
+                if val.ndim > 1 and val.shape[0] > 1:
+                    item += np.array2string(
+                        val, prefix=" " * len(item))
             else:
                 item += str(val)
             item += ","

--- a/fym/utils/parser.py
+++ b/fym/utils/parser.py
@@ -96,24 +96,37 @@ def update(sn, d):
 
 
 if __name__ == "__main__":
-    import numpy as np
+    # ``parser.parse``
     import fym.utils.parser as parser
+    from fym.core import BaseEnv, BaseSystem
 
+    json_dict = {
+        "env.kwargs": dict(dt=0.01, max_t=10),
+        "multicopter.nrotor": 6,
+        "multicopter.m": 3.,
+        "multicopter.LQRGain": {
+            "Q": [1, 1, 1, 1],
+            "R": [1, 1],
+        },
+        "actuator.tau": 1e-1,
+    }
+
+    cfg = parser.parse(json_dict)
+
+    # ``parser.update``
     cfg = parser.parse()
-    agents_cfg = {}
 
     def load_config():
         parser.update(cfg, {
-            "env.kwargs.dt": 0.01,
-            "env.kwargs.max_t": 10,
-            "env.solver": "rk4",
-        })
-
-        parser.update(agents_cfg, {
-            "CommonAgent.memory_len": 4000,
-            "CommonAgent.batch_size": 2000,
+            "env.kwargs": dict(dt=0.01, max_t=10),
+            "agent.memory_size": 1000,
+            "agent.minibatch_size": 32,
         })
 
     load_config()
+    cfg.env.kwargs.dt = 0.001
 
-    cfg.env.kwargs.dt = 0.02
+    # ``parser.decode``
+    cfg = parser.parse()
+    parser.update(cfg, {"env.kwargs": dict(dt=0.01, max_t=10)})
+    env = BaseEnv(**parser.decode(cfg.env.kwargs))

--- a/fym/utils/parser.py
+++ b/fym/utils/parser.py
@@ -25,19 +25,12 @@ def _make_clean(string):
     return re.sub(r"\W+|^(?=\d)", "_", string)
 
 
-def _put(d, k, v):
-    chunks = k.split(".", 1)
-    root_key = chunks[0]
-    if not root_key:
-        raise KeyError("empty root key")
-    if len(chunks) == 1:
-        d[root_key] = v
-    else:
-        if root_key not in d:
-            d[root_key] = {}
-        if not isinstance(d[root_key], dict):
-            raise KeyError("sub document is not a dictinary")
-        _put(d[root_key], chunks[1], v)
+def _put(a, b):
+    for k, v in b.items():
+        if k in a and isinstance(v, dict) and isinstance(a[k], dict):
+            _put(a[k], b[k])
+        else:
+            a[k] = b[k]
 
 
 def unwind_nested_dict(d):
@@ -45,7 +38,8 @@ def unwind_nested_dict(d):
     for k, v in d.items():
         if isinstance(v, dict):
             v = unwind_nested_dict(v)
-        _put(result, k, v)
+        d = reduce(lambda d, k: {k: d}, k.split(".")[::-1], v)
+        _put(result, d)
     return result
 
 

--- a/fym/utils/parser.py
+++ b/fym/utils/parser.py
@@ -20,12 +20,12 @@ class PrettySN(SN):
         return "\n".join(items)
 
 
-def make_clean(string):
+def _make_clean(string):
     """From https://stackoverflow.com/a/3305731"""
     return re.sub(r"\W+|^(?=\d)", "_", string)
 
 
-def put(d, k, v):
+def _put(d, k, v):
     chunks = k.split(".", 1)
     root_key = chunks[0]
     if not root_key:
@@ -37,7 +37,7 @@ def put(d, k, v):
             d[root_key] = {}
         if not isinstance(d[root_key], dict):
             raise KeyError("sub document is not a dictinary")
-        put(d[root_key], chunks[1], v)
+        _put(d[root_key], chunks[1], v)
 
 
 def unwind_nested_dict(d):
@@ -45,26 +45,8 @@ def unwind_nested_dict(d):
     for k, v in d.items():
         if isinstance(v, dict):
             v = unwind_nested_dict(v)
-        put(result, k, v)
+        _put(result, k, v)
     return result
-
-
-def merge_dict(a, b):
-    for k, v in b.items():
-        if k in a and isinstance(v, dict) and isinstance(a[k], dict):
-            merge_dict(a[k], b[k])
-        else:
-            a[k] = b[k]
-
-
-def dotdict2nestdict(data):
-    out = {}
-    for keystring, val in data.items():
-        if isinstance(val, dict):
-            val = dotdict2nestdict(val)
-        d = reduce(lambda d, k: {k: d}, keystring.split(".")[::-1], val)
-        merge_dict(out, d)
-    return out
 
 
 def encode(d):
@@ -77,9 +59,9 @@ def encode(d):
     out = PrettySN()
     for k, v in d.items():
         if isinstance(v, dict):
-            setattr(out, make_clean(k), encode(v))
+            setattr(out, _make_clean(k), encode(v))
         else:
-            setattr(out, make_clean(k), v)
+            setattr(out, _make_clean(k), v)
     return out
 
 

--- a/test/parser/agent.py
+++ b/test/parser/agent.py
@@ -1,0 +1,19 @@
+import fym.utils.parser as parser
+
+
+cfg = parser.parse({
+    "env.kwargs": dict(dt=0.01, max_t=10),
+    "multicopter.nrotor": 6,
+    "multicopter.m": 3.,
+    "multicopter.LQRGain": {
+        "Q": [1, 1, 1, 1],
+        "R": [1, 1],
+    },
+    "actuator.tau": 1e-1,
+})
+
+
+class LQR:
+    def __init__(self):
+        self.Q = cfg.multicopter.LQRGain.Q
+        self.R = cfg.multicopter.LQRGain.R

--- a/test/parser/main.py
+++ b/test/parser/main.py
@@ -1,0 +1,13 @@
+import fym.utils.parser as parser
+import agent
+
+
+parser.update(agent.cfg.multicopter, {
+    "LQRGain": {
+        "Q": [2, 2, 2, 2],
+        "R": [2, 2]
+    }
+})
+
+lqr = agent.LQR()
+print(lqr.Q, lqr.R)


### PR DESCRIPTION
---

This module assists setting up the configuration of each module and scripts. It parses JSON files with dot notation such as `settings.json` in [Visual Studio Code](https://code.visualstudio.com).

# Basic Usage

## `parser.parse`

`fym.utils.parser.parse` parses a JSON-like `dict` object to a nested [`types.SimpleNamespace`](https://docs.python.org/3/library/types.html#types.SimpleNamespace) object like following. It encodes a dotted key into a nested structure to make ease of grouping the configuration.

```python
import fym.utils.parser as parser
from fym.core import BaseEnv, BaseSystem

json_dict = {
    "env.kwargs": dict(dt=0.01, max_t=10),
    "multicopter.nrotor": 6,
    "multicopter.m": 3.,
    "multicopter.LQRGain": {
        "Q": [1, 1, 1, 1],
        "R": [1, 1],
    },
    "actuator.tau": 1e-1,
}

cfg = parser.parse(json_dict)
```

## `parser.update`

Because the `parser.parse` method returns a `SimpleNamespace` instance, the object should be updated or modified following the `SimpleNamespace`'s rule. To make ease of usage, `parser` provides a convenient method, `parser.update`, which can take a JSON-like `dict` with dotted keys or another `SimpleNamespace` instance. See the following example.

```python
cfg = parser.parse()

def load_config():
    parser.update(cfg, {
        "env.kwargs": dict(dt=0.01, max_t=10),
        "agent.memory_size": 1000,
        "agent.minibatch_size": 32,
    })

load_config()
cfg.env.kwargs.dt = 0.001
```

## `parser.decode`

Note that all the child elements in the returned `SimpleNamespace` is also a `SimpleNamespace`. A common method to conert it into a `dict` is `vars`, although it cannot handle the nested `dict`. `parser` module provides a `decode` method that converts the nested `SimpleNamespace` object into a nested `dict` which may useful to deal with keyword arguments.

```python
cfg = parser.parse()
parser.update(cfg, {"env.kwargs": dict(dt=0.01, max_t=10)})
env = BaseEnv(**parser.decode(cfg.env.kwargs))
```