### PR TITLE
Make some module called directly

### DIFF
--- a/fym/__init__.py
+++ b/fym/__init__.py
@@ -1,0 +1,5 @@
+from .core import BaseEnv, BaseSystem
+from .utils import parser
+from .utils.linearization import jacob_analytic, jacob_numerical
+from .logging import load, Logger
+from .agents.LQR import clqr, dlqr


### PR DESCRIPTION
List of directly callble modules/classes/methods:

```python
fym.BaseEnv  # fym.utils.BaseEnv
fym.BaseSystem  # fym.utils.BaseSystem
fym.parser  # fym.utils.parser
fym.jacob_analytic  # fym.utils.linearization.jacob_analytic
fym.jacob_numerical  # fym.utils.linearization.jacob_numerical
fym.load  # fym.logging.load
fym.Logger  # fym.logging.Logger
fym.clqr  # fym.agents.LQR.clqr
fym.dlqr  # fym.agents.LQR.dlqr
```