### PR TITLE
Block direct call of `Logger.record` method of inner Logger

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -75,6 +75,9 @@ class BaseEnv:
                 raise AttributeError(
                     "cannot assign delays before BaseEnv.__init__() call")
             delays[name] = value
+        elif isinstance(value, logging.Logger):
+            value._inner = True
+            super().__setattr__(name, value)
         else:
             super().__setattr__(name, value)
 
@@ -225,7 +228,7 @@ class BaseEnv:
                         self._log_set_dot = False
                 if self.logger_callback:
                     data.update(self.logger_callback(t, **kwargs))
-                self.logger.record(**(data or dict(t=t, **self.observe_dict())))
+                self.logger._record(**(data or dict(t=t, **self.observe_dict())))
                 self.clock._tick_minor()
 
         # Update the systems' state

--- a/fym/logging.py
+++ b/fym/logging.py
@@ -23,6 +23,8 @@ class Logger:
         self.max_len = int(max_len)
         self._info = {}
 
+        self._inner = False
+
         self.clear()
 
     @property
@@ -43,6 +45,10 @@ class Logger:
         self.index = 0
 
     def record(self, **kwargs):
+        assert not self._inner, "Inner loggers are not allowed to record directly"
+        self._record(**kwargs)
+
+    def _record(self, **kwargs):
         """Record a dictionary or a numeric data preserving the structure."""
         self._rec_update(self.buffer, kwargs)
         self.index += 1


### PR DESCRIPTION
Inner ``Logger``s was designed to record inner data of ``BaseEnv``, so attempts to directly record any data to the inner logger should be blocked.

I've made a method ``Logger._record`` that works the same as the previous ``Logger.record`` method, and add a line to check the ``Logger`` is inner or not inside the previous ``Logger.record`` method for compatibility.

This resolves #179 .