### PR TITLE
Remove the registered attribute

### DIFF
--- a/fym/core.py
+++ b/fym/core.py
@@ -93,6 +93,9 @@ class BaseEnv:
             if isinstance(value, BaseEnv) or value._name is None:
                 value._name = name
             self.indexing()
+
+            self.__dict__.pop(name, None)
+
             return
         elif isinstance(value, Delay):
             delays = self.__dict__.get("_delays")
@@ -101,6 +104,9 @@ class BaseEnv:
                     "cannot assign delays before BaseEnv.__init__() call"
                 )
             delays[name] = value
+
+            self.__dict__.pop(name, None)
+
             return
         elif isinstance(value, logging.Logger):
             value._inner = True


### PR DESCRIPTION
When registering a `BaseEnv` or `BaseSystem`, instead of registering it to `self.__dict__`, the Fym saves it to `self._systems_dict`. This behavior is intended to distinguish the systems and normal attiributes.

However, the previous code does not delete the existing attribute after registering it to `self._systems_dict`.
This glitch is fixed in this commit.